### PR TITLE
added npm install steps to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ SWDestinyDB
 This guide assumes you know how to use the command-line and that your machine has php and mysql installed.
 
 - install composer: https://getcomposer.org/download/
+- install npm: https://www.npmjs.com/
 - clone the repo somewhere
 - cd to it
+- run `npm install`
 - run `composer install` (at the end it will ask for the database configuration parameters)
 - run `php app/console doctrine:database:create`
 - run `php app/console doctrine:schema:create`


### PR DESCRIPTION
I ran into this problem while trying to set up a local dev environment.

```
  [Assetic\Exception\FilterException]                                                                                                                                                                       
  An error occurred while running:                                                                                                                                                                          
  '/home/stefan/.nvm/versions/node/v6.4.0/bin/node' 'node_modules/handlebars/bin/handlebars' '/tmp/assetic_handlebars_in5835166bf3f0d/card_modal-info.handlebars' '-f' '/tmp/assetic_handlebars_outUL16wf'  
  Error Output:                                                                                                                                                                                             
  module.js:457                                                                                                                                                                                             
      throw err;                                                                                                                                                                                            
      ^                                                                                                                                                                                                     
  Error: Cannot find module '/home/stefan/dev/projects/swdestinydb/node_modules/handlebars/bin/handlebars' 
```

Turns out `npm install` needs to be run before `composer install`, otherwise Assetic will barf up.