### PR TITLE
do not remote null-valued attributes.

### DIFF
--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -423,7 +423,6 @@ class CardsData
 		if($api) {
 			unset($cardinfo['id']);
             $cardinfo['cp'] = $card->getHighestCostPointsValue();
-			$cardinfo = array_filter($cardinfo, function ($var) { return isset($var); });
 			if(!$cardinfo['has_die']) unset($cardinfo['sides']);
 			else $cardinfo['sides'] = map($cardinfo['sides'], function($side) { return $side->toString(); });
 


### PR DESCRIPTION
fixes #24 

this one was tricky. turns out that sorting a collection in Forerunner that has sparse attributes (in this case `health`) across its items does not work correctly. Sorting on `null` works. 

Now, this breaks #7  even worse (working on a fix for that), so I'd hold off on merging this PR until that issue has been addressed.

Nonetheless, this can be reviewed already.