### PR TITLE
Cost point sorting fix

### DIFF
--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -812,4 +812,39 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     {
         return $this->points;
     }
+
+    /**
+     * Converts cost and points into a comparable value-representation, and then returns the higher value of the both.
+     * The higher value of the both is returned.
+     * @link https://github.com/fafranco82/swdestinydb/issues/7
+     * @return int
+     */
+    public function getHighestCostPointsValue()
+    {
+        $cost = $this->getCost();
+        $points = $this->getPoints();
+        $value = -1;
+        if (is_null($cost) && is_null($points)) {
+            return $value;
+        }
+
+        $cost = is_null($cost) ? 0 : $cost;
+        $cost = $cost * 100;
+
+        if (is_null($points)) {
+            $points = 0;
+        } else {
+            $pos = strpos($points, '/');
+            if (false === $pos) {
+                $points = (int) $points;
+                $points = $points * 100;
+            } else {
+                $oneDiePoints = (int) substr($points, 0, $pos);
+                $twoDicePoints = (int) substr($points, $pos + 1);
+                $points = $oneDiePoints * 100 + $twoDicePoints;
+            }
+        }
+
+        return max($cost, $points);
+    }
 }

--- a/src/AppBundle/Resources/views/Builder/tab-pane-build.html.twig
+++ b/src/AppBundle/Resources/views/Builder/tab-pane-build.html.twig
@@ -85,7 +85,7 @@
 						</a>
 					</th>
 					<th class="cost">
-						<a href="#" data-sort="points|cost" title="{{ 'card.info.points_cost' | trans}}">
+						<a href="#" data-sort="cp" title="{{ 'card.info.points_cost' | trans}}">
 							{{ 'card.info.short.points_cost' | trans}}
 						</a>
 					</th>

--- a/src/AppBundle/Resources/views/Collection/index.html.twig
+++ b/src/AppBundle/Resources/views/Collection/index.html.twig
@@ -127,7 +127,7 @@
 						<a href="#" data-sort="affiliation_code">{{ 'card.info.affiliation' | trans }}</a>
 					</th>
 					<th class="hidden-sm hidden-xs" title="{{'card.info.points_cost' | trans}}">
-						<a href="#" data-sort="points|cost">{{ 'card.info.medium.points_cost' | trans }}</a>
+						<a href="#" data-sort="cp">{{ 'card.info.medium.points_cost' | trans }}</a>
 					</th>
 					<th class="hidden-sm hidden-xs">
 						<a href="#" data-sort="health">{{ 'card.info.health' | trans }}</a>

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -422,7 +422,7 @@ class CardsData
 
 		if($api) {
 			unset($cardinfo['id']);
-            $cardinfo['cp'] = $this->calculateCostPoints($cardinfo['cost'], $cardinfo['points']);
+            $cardinfo['cp'] = $card->getHighestCostPointsValue();
 			$cardinfo = array_filter($cardinfo, function ($var) { return isset($var); });
 			if(!$cardinfo['has_die']) unset($cardinfo['sides']);
 			else $cardinfo['sides'] = map($cardinfo['sides'], function($side) { return $side->toString(); });
@@ -574,39 +574,5 @@ class CardsData
     		}
     	}
     	 
-    }
-
-    /**
-     * Calculates and returns a common value-representation of card cost and points
-     * than can be used for sorting purposes.
-     * @link https://github.com/fafranco82/swdestinydb/issues/7
-     * @param int|null $cost
-     * @param string|null $points
-     * @return int
-     */
-    protected function calculateCostPoints($cost, $points)
-    {
-        $value = -1;
-        if (is_null($cost) && is_null($points)) {
-            return $value;
-        }
-
-        $cost = is_null($cost) ? 0 : $cost;
-
-        if (is_null($points)) {
-            $points = 0;
-        } else {
-            $pos = strpos($points, '/');
-            if (-1 === $pos) {
-                $points = (int) $points;
-                $points = $points * 100;
-            } else {
-                $oneDiePoints = (int) substr($points, 0, $pos);
-                $twoDicePoints = (int) substr($points, $pos + 1);
-                $points = $oneDiePoints * 100 + $twoDicePoints;
-            }
-        }
-
-        return max($cost, $points);
     }
 }

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -422,6 +422,7 @@ class CardsData
 
 		if($api) {
 			unset($cardinfo['id']);
+            $cardinfo['cp'] = $this->calculateCostPoints($cardinfo['cost'], $cardinfo['points']);
 			$cardinfo = array_filter($cardinfo, function ($var) { return isset($var); });
 			if(!$cardinfo['has_die']) unset($cardinfo['sides']);
 			else $cardinfo['sides'] = map($cardinfo['sides'], function($side) { return $side->toString(); });
@@ -573,5 +574,39 @@ class CardsData
     		}
     	}
     	 
+    }
+
+    /**
+     * Calculates and returns a common value-representation of card cost and points
+     * than can be used for sorting purposes.
+     * @link https://github.com/fafranco82/swdestinydb/issues/7
+     * @param int|null $cost
+     * @param string|null $points
+     * @return int
+     */
+    protected function calculateCostPoints($cost, $points)
+    {
+        $value = -1;
+        if (is_null($cost) && is_null($points)) {
+            return $value;
+        }
+
+        $cost = is_null($cost) ? 0 : $cost;
+
+        if (is_null($points)) {
+            $points = 0;
+        } else {
+            $pos = strpos($points, '/');
+            if (-1 === $pos) {
+                $points = (int) $points;
+                $points = $points * 100;
+            } else {
+                $oneDiePoints = (int) substr($points, 0, $pos);
+                $twoDicePoints = (int) substr($points, $pos + 1);
+                $points = $oneDiePoints * 100 + $twoDicePoints;
+            }
+        }
+
+        return max($cost, $points);
     }
 }


### PR DESCRIPTION
fixes #7 by adding a computed property "cp" to the output of the `/cards` API endpoint.

the value represents the higher value of either converted cost or converted points.

the converted value is an integer that lends itself to easy comparison.

conversion:

1. converted cost is cost times hundred. e.g. 3 => 300
2. converted points (one die) is points time hundred. 3. => 300
3. converted points (two die) is first die times hundred plus second die. e.g. 10/13 => 1013 
4. no points nor cost (e.g. battlefields) result in a converted value of -1.  

the rest was fixing data bindings in the templates.

please review, thanks!