### PR TITLE
better defaults for AWS keys.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -31,6 +31,6 @@ parameters:
     google_adsense_slot: 0000000000
 
     #AWS
-    aws_access_key_id: ~
-    aws_secret_access_key: ~
+    aws_access_key_id: false
+    aws_secret_access_key: false
     s3_bucket: ~


### PR DESCRIPTION
set them to `FALSE` by default, otherwise `composer install` will error out when no values are provided. 
see https://github.com/fafranco82/swdestinydb/issues/39#issuecomment-266538148