### PR TITLE
Added a link and a twig for exporting decks as TableTopSimulatorJSON

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -348,6 +348,7 @@ class ImportStdCommand extends ContainerAwareCommand
 		foreach($cardsData as $cardData) {
 			$card = $this->getEntityFromData('AppBundle\Entity\Card', $cardData, [
 					'code',
+					'ttscardid',
 					'deck_limit',
 					'position',
 					'name',

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -252,6 +252,48 @@ class BuilderController extends Controller
 
     }
 
+		public function ttsexportAction ($deck_id)
+    {
+		/* @var $em \Doctrine\ORM\EntityManager */
+        $em = $this->getDoctrine()->getManager();
+
+        /* @var $deck \AppBundle\Entity\Deck */
+        $deck = $em->getRepository('AppBundle:Deck')->find($deck_id);
+
+        $is_owner = $this->getUser() && $this->getUser()->getId() == $deck->getUser()->getId();
+        if(!$deck->getUser()->getIsShareDecks() && !$is_owner) {
+        	return $this->render(
+        			'AppBundle:Default:error.html.twig',
+        			array(
+        					'pagetitle' => "Error",
+        					'error' => 'You are not allowed to view this deck. To get access, you can ask the deck owner to enable "Share your decks" on their account.'
+        			)
+        	);
+        }
+
+        $factionNames = [];
+        foreach($this->getDoctrine()->getRepository('AppBundle:Faction')->findAllAndOrderByName() as $faction) {
+            $factionNames[$faction->getCode()] = $faction->getName();
+        }
+
+        $content = $this->renderView('AppBundle:Export:tts.json.twig', [
+        	"deck" => $deck->getTtsExport(),
+            "factionNames" => $factionNames
+      	]);
+        $content = str_replace("\n", "\r\n", $content);
+
+		$response = new Response();
+		$response->headers->set('Content-Type', 'application/json');
+		$response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+		    ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+				$this->get('texts')->slugify($deck->getName()) . '.json'
+		));
+
+		$response->setContent($content);
+		return $response;
+
+    }
+
     public function octgnexportAction ($deck_id)
     {
         /* @var $em \Doctrine\ORM\EntityManager */

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -760,6 +760,40 @@ class SocialController extends Controller
     /*
 	 * returns a text file with the content of a decklist
 	 */
+    public function ttsexportAction ($decklist_id, Request $request)
+    {
+        $response = new Response();
+        $response->setPublic();
+        $response->setMaxAge($this->container->getParameter('cache_expiration'));
+
+        /* @var $em \Doctrine\ORM\EntityManager */
+        $em = $this->getDoctrine()->getManager();
+
+        /* @var $decklist \AppBundle\Entity\Decklist */
+        $decklist = $em->getRepository('AppBundle:Decklist')->find($decklist_id);
+        if (! $decklist)
+            throw new NotFoundHttpException("Unable to find decklist.");
+
+        $content = $this->renderView('AppBundle:Export:tts.json.twig', [
+        	"deck" => $decklist->getTtsExport()
+      	]);
+        $content = str_replace("\n", "\r\n", $content);
+
+        $response = new Response();
+
+        $response->headers->set('Content-Type', 'application/json');
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+        		ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+        		$decklist->getNameCanonical() . '.json'
+        ));
+
+        $response->setContent($content);
+        return $response;
+    }
+
+    /*
+	 * returns a text file with the content of a decklist
+	 */
     public function textexportAction ($decklist_id, Request $request)
     {
         $response = new Response();

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -23,6 +23,7 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
         ];
     
         $optionalFields = [
+                'ttscardid',
                 'illustrator',
                 'flavor',
                 'text',
@@ -116,6 +117,11 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
      * @var string
      */
     private $code;
+
+    /**
+     * @var string
+     */
+    private $ttscardid;
 
     /**
      * @var string
@@ -267,6 +273,30 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     public function getCode()
     {
         return $this->code;
+    }
+
+    /**
+     * Set ttscardid
+     *
+     * @param string $code
+     *
+     * @return Card
+     */
+    public function setTtscardid($ttscardid)
+    {
+        $this->ttscardid = $ttscardid;
+
+        return $this;
+    }
+
+    /**
+     * Get ttscardid
+     *
+     * @return string
+     */
+    public function getTtscardid()
+    {
+        return $this->ttscardid;
     }
 
     /**

--- a/src/AppBundle/Form/CardType.php
+++ b/src/AppBundle/Form/CardType.php
@@ -16,6 +16,7 @@ class CardType extends AbstractType
             ->add('quantity')
             ->add('deck_limit')
             ->add('code')
+            ->add('ttscardid')
             ->add('type', 'entity', array('class' => 'AppBundle:Type', 'property' => 'name'))
             ->add('faction', 'entity', array('class' => 'AppBundle:Faction', 'property' => 'name'))
             ->add('name')

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -42,4 +42,23 @@ class ExportableDeck
 				'slots_by_type' => $slots->getSlotsByType()
 		];
 	}
+
+	public function getTtsExport()
+	{
+		$slots = $this->getSlots();
+
+		$decklist_factions = $slots->getCountByFaction();
+        arsort($decklist_factions);
+        $factions = array_keys(array_filter($decklist_factions, function($v) {
+            return $v > 0;
+        }));
+
+		return [
+				'name' => $this->getName(),
+				'affiliation' => $this->getAffiliation(),
+				'factions' => $factions,
+				'included_sets' => $slots->getIncludedSets(),
+				'slots_by_type' => $slots->getSlotsByType()
+		];
+	}
 }

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -67,6 +67,10 @@ AppBundle\Entity\Card:
             type: string
             length: 255
             nullable: false
+        ttscardid:
+            type: string
+            length: 255
+            nullable: true
         name:
             type: string
             length: 50

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -111,6 +111,14 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
+deck_export_tts:
+    path: /export/tts/{deck_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Builder:ttsexport
+    requirements:
+        deck_id: \d+
+
 deck_export_octgn_list:
     path: /export/octgn/list
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -15,6 +15,14 @@ decklist_export_text:
     requirements:
         decklist_id: \d+
 
+decklist_export_tts:
+    path: /export/tts/{decklist_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Social:ttsexport
+    requirements:
+        decklist_id: \d+
+
 decklist_detail:
     path: /view/{decklist_id}/{decklist_name}
     methods: [GET]

--- a/src/AppBundle/Resources/public/js/ui.decklist.js
+++ b/src/AppBundle/Resources/public/js/ui.decklist.js
@@ -28,6 +28,9 @@
 		case 'btn-download-text':
 			location.href = Routing.generate('decklist_export_text', {decklist_id:app.deck.get_id()});
 			break;
+		case 'btn-download-tts':
+			location.href = Routing.generate('decklist_export_tts', {decklist_id:app.deck.get_id()});
+			break;
 		case 'btn-download-octgn':
 			location.href = Routing.generate('decklist_export_octgn', {decklist_id:app.deck.get_id()});
 			break;

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -54,6 +54,7 @@
 						</button>
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_tts', {deck_id:deck_id}) }}">TableTop Simulator</a></li>
 						</ul>
 					</div>
 				</div>

--- a/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
@@ -13,6 +13,7 @@
 	</button>
 	<ul class="dropdown-menu" role="menu">
 		<li><a href="#" id="btn-download-text">{{ 'decks.form.download.text' | trans }}</a></li>
+		<li><a href="#" id="btn-download-tts">TableTop Simulator</a></li>
 	</ul>
 </div>
 {#

--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -1,0 +1,273 @@
+{
+	"SaveName": "",
+	"GameMode": "",
+	"Date": "",
+	"Table": "",
+	"Sky": "",
+	"Note": "",
+	"Rules": "",
+	"PlayerTurn": "",
+	"LuaScript": "",
+	"LuaScriptState": "",
+	"ObjectStates": [
+		{
+			"Name": "Bag",
+			"Transform": {
+				"posX": 0,
+				"posY": 0,
+				"posZ": 0,
+				"rotX": 0,
+				"rotY": 180,
+				"rotZ": 0,
+				"scaleX": 1,
+				"scaleY": 1,
+				"scaleZ": 1
+			},
+			"Nickname": "{{ deck.name }}",
+			"Description": "Exported from SWDestinyDB.com",
+			"ColorDiffuse": {
+				"r": 0.129,
+				"g": 0.694,
+				"b": 0.607
+			},
+			"Locked": false,
+			"Grid": true,
+			"Snap": true,
+			"Autoraise": true,
+			"Sticky": true,
+			"Tooltip": true,
+			"MaterialIndex": -1,
+			"MeshIndex": -1,
+			"LuaScript": "",
+			"LuaScriptState": "",
+			"ContainedObjects": [
+				{# BattleField #}
+				{% set battlefield = deck.slots_by_type.battlefield.0.card %}
+				{
+					"Name": "Card",
+					"Transform": {
+						"posX": 0.0,
+						"posY": 0.0,
+						"posZ": 0.0,
+						"rotX": 0.0,
+						"rotY": 270,
+						"rotZ": 0.0,
+						"scaleX": 1.42055011,
+						"scaleY": 1,
+						"scaleZ": 1.42055011
+					},
+					"Nickname": "{{ battlefield.name }}",
+					"Description": "",
+					"ColorDiffuse": {
+						"r": 0.713235259,
+						"g": 0.713235259,
+						"b": 0.713235259
+					},
+					"Locked": false,
+					"Grid": true,
+					"Snap": true,
+					"Autoraise": true,
+					"Sticky": true,
+					"Tooltip": true,
+					"CardID": {{ battlefield.ttscardid }},
+					"SidewaysCard": true,
+					"CustomDeck": {
+						{# All Battlefields use CustomDeck 18 #}
+						"18": {
+							"FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LUHgyNXVudlY4OVE",
+							"BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+							"NumWidth": 10,
+							"NumHeight": 7,
+							"BackIsHidden": true,
+							"UniqueBack": false
+						}
+					},
+					"LuaScript": "",
+					"LuaScriptState": "",
+					"GUID": ""
+				},
+				{# Characters #}
+				{% for slot in deck.slots_by_type.character %}
+				{
+			    "Name": "Card",
+			    "Transform": {
+			      "posX": 0.0,
+			      "posY": 0.0,
+			      "posZ": 0.0,
+			      "rotX": 0.0,
+			      "rotY": 0.0,
+			      "rotZ": 0.0,
+			      "scaleX": 1.42055011,
+			      "scaleY": 1.0,
+			      "scaleZ": 1.42055011
+			    },
+			    "Nickname": "{{ slot.card.name }}",
+			    "Description": "{% if slot.dice == 2 %}elite{% endif %}",
+			    "ColorDiffuse": {
+			      "r": 0.713235259,
+			      "g": 0.713235259,
+			      "b": 0.713235259
+			    },
+			    "Locked": false,
+			    "Grid": true,
+			    "Snap": true,
+			    "Autoraise": true,
+			    "Sticky": true,
+			    "Tooltip": true,
+			    "CardID": {{ slot.card.ttscardid }},
+			    "SidewaysCard": false,
+			    "CustomDeck": {
+			      "13": {
+			        "FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LX3UxM0ctWVRyTmc",
+			        "BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+			        "NumWidth": 10,
+			        "NumHeight": 7,
+			        "BackIsHidden": true,
+			        "UniqueBack": false
+			      }
+			    },
+			    "LuaScript": "",
+			    "LuaScriptState": "",
+			    "GUID": ""
+			  },
+				{% endfor %}
+				{# Deck of Other Cards #}
+				{
+					"Name": "Deck",
+					"Transform": {
+						"posX": 0,
+						"posY": 0,
+						"posZ": 0,
+						"rotX": 0,
+						"rotY": 0,
+						"rotZ": 180,
+						"scaleX": 1.42055011,
+						"scaleY": 1,
+						"scaleZ": 1.42055011
+					},
+					"Nickname": "Events, Supports, Upgrades",
+					"Description": "",
+					"ColorDiffuse": {
+						"r": 0.713235259,
+						"g": 0.713235259,
+						"b": 0.713235259
+					},
+					"Locked": false,
+					"Grid": true,
+					"Snap": true,
+					"Autoraise": true,
+					"Sticky": true,
+					"Tooltip": true,
+					"SidewaysCard": false,
+					"DeckIDs": [
+						{% set allSlots = deck.slots_by_type.upgrade %}
+						{% set allSlots = allSlots|merge(deck.slots_by_type.support) %}
+						{% set allSlots = allSlots|merge(deck.slots_by_type.event) %}
+						{% for slot in allSlots %}
+						{{ slot.card.ttscardid }}{% if not loop.last %},{% endif %}
+						{% endfor %}
+					],
+					"CustomDeck": {
+						"13": {
+							"FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LX3UxM0ctWVRyTmc",
+							"BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+							"NumWidth": 10,
+							"NumHeight": 7,
+							"BackIsHidden": true,
+							"UniqueBack": false
+						},
+						"14": {
+							"FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LbWxBTlVoVUZ0QkE",
+							"BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+							"NumWidth": 10,
+							"NumHeight": 7,
+							"BackIsHidden": true,
+							"UniqueBack": false
+						},
+						"19": {
+							"FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LR09TdWYtUkloUzQ",
+							"BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+							"NumWidth": 10,
+							"NumHeight": 7,
+							"BackIsHidden": true,
+							"UniqueBack": false
+						}
+					},
+					"LuaScript": "",
+					"LuaScriptState": "",
+					"ContainedObjects": [
+						{% for slot in allSlots %}
+						{% for i in range (1,slot.quantity) %}
+							{
+			          "Name": "Card",
+			          "Transform": {
+			            "posX": 0.0,
+			            "posY": 0.0,
+			            "posZ": 0.0,
+			            "rotX": 0.0,
+			            "rotY": 0.0,
+			            "rotZ": 0.0,
+			            "scaleX": 1.42055011,
+			            "scaleY": 1.0,
+			            "scaleZ": 1.42055011
+			          },
+			          "Nickname": "{{ slot.card.name }}",
+			          "Description": "",
+			          "ColorDiffuse": {
+			            "r": 0.713235259,
+			            "g": 0.713235259,
+			            "b": 0.713235259
+			          },
+			          "Locked": false,
+			          "Grid": true,
+			          "Snap": true,
+			          "Autoraise": true,
+			          "Sticky": true,
+			          "Tooltip": true,
+			          "CardID": {{ slot.card.ttscardid }},
+			          "SidewaysCard": false,
+			          "CustomDeck": {
+									{%if slot.card.ttscardid[:2] == 13 %}
+										"13": {
+											"FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LX3UxM0ctWVRyTmc",
+											"BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+											"NumWidth": 10,
+											"NumHeight": 7,
+											"BackIsHidden": true,
+											"UniqueBack": false
+										}
+									{% elseif slot.card.ttscardid[:2] == 14 %}
+										"14": {
+				              "FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LbWxBTlVoVUZ0QkE",
+				              "BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+				              "NumWidth": 10,
+				              "NumHeight": 7,
+				              "BackIsHidden": true,
+				              "UniqueBack": false
+				            }
+									{% elseif slot.card.ttscardid[:2] == 19 %}
+										"19": {
+				              "FaceURL": "http://drive.google.com/uc?id=0B0v-LHuAfe7LR09TdWYtUkloUzQ",
+				              "BackURL": "http://cloud-3.steamusercontent.com/ugc/263845944692793410/D285F2B6F28F272FAAD1BFA25D6DD12660C9972E/",
+				              "NumWidth": 10,
+				              "NumHeight": 7,
+				              "BackIsHidden": true,
+				              "UniqueBack": false
+				            }
+									{% endif %}
+			          },
+			          "LuaScript": "",
+			          "LuaScriptState": "",
+			          "GUID": ""
+			        }{% if (not loop.parent.loop.last) or (loop.parent.loop.last and not loop.last) %},{% endif %}
+						{% endfor %}
+						{% endfor %}
+					],
+					"GUID": ""
+				}
+      ],
+			"GUID": ""
+		}
+	],
+	"TabStates": {}
+}


### PR DESCRIPTION
This is paired with pull request in the swdestiny-json-data repository.
There is a chance that the only usable thing from this merge is the update to the data files, and the tts.json.twig.
I did not touch the messages.xx.xliff  to make a message for "decks.form.download.tts". So, I hardcoded a link in the `toolbar.html.twig` and the `deckview.html.twig`
