### PR TITLE
added random numbers and GUIDs to the tabletop export

### DIFF
--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -20,11 +20,11 @@ class ExportableDeck
 				'characters' => $slots->getCharacterDeck()->getContent(),
 				'version' => $this->getVersion(),
 		];
-	
+
 		return $array;
 	}
-	
-	public function getTextExport() 
+
+	public function getTextExport()
 	{
 		$slots = $this->getSlots();
 
@@ -47,6 +47,11 @@ class ExportableDeck
 	{
 		$slots = $this->getSlots();
 
+		$guidArray = [];
+		for ($i = 1; $i <= 40; $i++) {
+			array_push($guidArray, bin2hex(openssl_random_pseudo_bytes(3)));
+		}
+
 		$decklist_factions = $slots->getCountByFaction();
         arsort($decklist_factions);
         $factions = array_keys(array_filter($decklist_factions, function($v) {
@@ -58,7 +63,8 @@ class ExportableDeck
 				'affiliation' => $this->getAffiliation(),
 				'factions' => $factions,
 				'included_sets' => $slots->getIncludedSets(),
-				'slots_by_type' => $slots->getSlotsByType()
+				'slots_by_type' => $slots->getSlotsByType(),
+				'guidArray' => $guidArray
 		];
 	}
 }

--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -1,3 +1,4 @@
+{% set guidCount = 0 %}
 {
 	"SaveName": "",
 	"GameMode": "",
@@ -13,12 +14,12 @@
 		{
 			"Name": "Bag",
 			"Transform": {
-				"posX": 0,
-				"posY": 0,
-				"posZ": 0,
-				"rotX": 0,
+				"posX": {{ random(999) /1000 }},
+				"posY": {{ random(999) /1000 }},
+				"posZ": {{ random(999) /1000 }},
+				"rotX": {{ random(999) /1000 }},
 				"rotY": 180,
-				"rotZ": 0,
+				"rotZ": {{ random(999) /1000 }},
 				"scaleX": 1,
 				"scaleY": 1,
 				"scaleZ": 1
@@ -46,12 +47,12 @@
 				{
 					"Name": "Card",
 					"Transform": {
-						"posX": 0.0,
-						"posY": 0.0,
-						"posZ": 0.0,
-						"rotX": 0.0,
+						"posX": {{ random(999) /1000 }},
+						"posY": {{ random(999) /1000 }},
+						"posZ": {{ random(999) /1000 }},
+						"rotX": {{ random(999) /1000 }},
 						"rotY": 270,
-						"rotZ": 0.0,
+						"rotZ": {{ random(999) /1000 }},
 						"scaleX": 1.42055011,
 						"scaleY": 1,
 						"scaleZ": 1.42055011
@@ -84,19 +85,20 @@
 					},
 					"LuaScript": "",
 					"LuaScriptState": "",
-					"GUID": ""
+					"GUID": "{{ deck.guidArray[guidCount] }}"
+					{% set guidCount = guidCount + 1 %}
 				},
 				{# Characters #}
 				{% for slot in deck.slots_by_type.character %}
 				{
 			    "Name": "Card",
 			    "Transform": {
-			      "posX": 0.0,
-			      "posY": 0.0,
-			      "posZ": 0.0,
-			      "rotX": 0.0,
-			      "rotY": 0.0,
-			      "rotZ": 0.0,
+			      "posX": {{ random(999) /1000 }},
+			      "posY": {{ random(999) /1000 }},
+			      "posZ": {{ random(999) /1000 }},
+			      "rotX": {{ random(999) /1000 }},
+			      "rotY": {{ random(999) /1000 }},
+			      "rotZ": {{ random(999) /1000 }},
 			      "scaleX": 1.42055011,
 			      "scaleY": 1.0,
 			      "scaleZ": 1.42055011
@@ -128,18 +130,19 @@
 			    },
 			    "LuaScript": "",
 			    "LuaScriptState": "",
-			    "GUID": ""
+					"GUID": "{{ deck.guidArray[guidCount] }}"
+					{% set guidCount = guidCount + 1 %}
 			  },
 				{% endfor %}
 				{# Deck of Other Cards #}
 				{
 					"Name": "Deck",
 					"Transform": {
-						"posX": 0,
-						"posY": 0,
-						"posZ": 0,
-						"rotX": 0,
-						"rotY": 0,
+						"posX": {{ random(999) /1000 }},
+						"posY": {{ random(999) /1000 }},
+						"posZ": {{ random(999) /1000 }},
+						"rotX": {{ random(999) /1000 }},
+						"rotY": {{ random(999) /1000 }},
 						"rotZ": 180,
 						"scaleX": 1.42055011,
 						"scaleY": 1,
@@ -201,12 +204,12 @@
 							{
 			          "Name": "Card",
 			          "Transform": {
-			            "posX": 0.0,
-			            "posY": 0.0,
-			            "posZ": 0.0,
-			            "rotX": 0.0,
-			            "rotY": 0.0,
-			            "rotZ": 0.0,
+			            "posX": {{ random(999) /1000 }},
+			            "posY": {{ random(999) /1000 }},
+			            "posZ": {{ random(999) /1000 }},
+			            "rotX": {{ random(999) /1000 }},
+			            "rotY": {{ random(999) /1000 }},
+			            "rotZ": {{ random(999) /1000 }},
 			            "scaleX": 1.42055011,
 			            "scaleY": 1.0,
 			            "scaleZ": 1.42055011
@@ -258,15 +261,18 @@
 			          },
 			          "LuaScript": "",
 			          "LuaScriptState": "",
-			          "GUID": ""
+								"GUID": "{{ deck.guidArray[guidCount] }}"
+								{% set guidCount = guidCount + 1 %}
 			        }{% if (not loop.parent.loop.last) or (loop.parent.loop.last and not loop.last) %},{% endif %}
 						{% endfor %}
 						{% endfor %}
 					],
-					"GUID": ""
+					"GUID": "{{ deck.guidArray[guidCount] }}"
+					{% set guidCount = guidCount + 1 %}
 				}
       ],
-			"GUID": ""
+			"GUID": "{{ deck.guidArray[guidCount] }}"
+			{% set guidCount = guidCount + 1 %}
 		}
 	],
 	"TabStates": {}


### PR DESCRIPTION
I think not having GUIDs on each of the cards is causing a problem for some of them to disappear while in TableTop Simulator. 