### PR TITLE
SWD-73 Added logic to allow multiple non-elite characters.

### DIFF
--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -90,6 +90,7 @@
 				},
 				{# Characters #}
 				{% for slot in deck.slots_by_type.character %}
+				{% for i in range (1, min(slot.dice,slot.card.deckLimit)) %}
 				{
 			    "Name": "Card",
 			    "Transform": {
@@ -104,7 +105,7 @@
 			      "scaleZ": 1.42055011
 			    },
 			    "Nickname": "{{ slot.card.name|raw|replace({"'":""}) }}",
-			    "Description": "{% if slot.dice == 2 %}elite{% endif %}",
+			    "Description": "{% if slot.dice == 2 and slot.card.deckLimit == 1 %}elite{% endif %}",
 			    "ColorDiffuse": {
 			      "r": 0.713235259,
 			      "g": 0.713235259,
@@ -133,6 +134,7 @@
 					"GUID": "{{ deck.guidArray[guidCount] }}"
 					{% set guidCount = guidCount + 1 %}
 			  },
+				{% endfor %}
 				{% endfor %}
 				{# Deck of Other Cards #}
 				{


### PR DESCRIPTION
Resolving an issue where if you have, for example, 2 Storm Troopers, the code was recognizing this a single "Elite" character with two dice.