### PR TITLE
Use raw filter to avoid HTML code in text export

### DIFF
--- a/src/AppBundle/Resources/views/macros.html.twig
+++ b/src/AppBundle/Resources/views/macros.html.twig
@@ -63,4 +63,4 @@
 {% if slot.card.hasDie %} ({{slot.dice}} <span class="icon icon-die"></span>){% endif %}
 {% endmacro %}
 
-{% macro slot_plain(slot, qty) %}{% if qty > 0 %}{{qty}}x {% endif %}{{ slot.card.name }}{% if slot.card.subtitle %}, {{slot.card.subtitle}}{% endif %} ({{ slot.card.set.name }} #{{slot.card.position}}){% endmacro %}
+{% macro slot_plain(slot, qty) %}{% if qty > 0 %}{{qty}}x {% endif %}{{ slot.card.name|raw }}{% if slot.card.subtitle %}, {{slot.card.subtitle|raw}}{% endif %} ({{ slot.card.set.name }} #{{slot.card.position}}){% endmacro %}


### PR DESCRIPTION
Added raw filter for text output so that HTML code does not show up for cards like "Maul's Lightsaber".