### PR TITLE
Support double quotes in card names etc.

### DIFF
--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -25,7 +25,7 @@
 				"scaleY": 1,
 				"scaleZ": 1
 			},
-			"Nickname": "{{ deck.name|raw }}",
+			"Nickname": "{{ deck.name|raw|replace({"\"":"\\\""}) }}",
 			"Description": "Exported from SWDestinyDB.com",
 			"ColorDiffuse": {
 				"r": 0.129,
@@ -58,7 +58,7 @@
 						"scaleY": 1,
 						"scaleZ": 1.42055011
 					},
-					"Nickname": "{{ battlefield.name|raw }}",
+					"Nickname": "{{ battlefield.name|raw|replace({"\"":"\\\""}) }}",
 					"Description": "{{battlefield.set.code}} {{battlefield.position}}",
 					"ColorDiffuse": {
 						"r": 0.713235259,
@@ -104,7 +104,7 @@
 						"scaleY": 1,
 						"scaleZ": 1.42055011
 					},
-					"Nickname": "{{ plot.card.name|raw }}",
+					"Nickname": "{{ plot.card.name|raw|replace({"\"":"\\\""}) }}",
 					"Description": "{{plot.card.set.code}} {{plot.card.position}}",
 					"ColorDiffuse": {
 						"r": 0.713235259,
@@ -153,7 +153,7 @@
 			      "scaleY": 1.0,
 			      "scaleZ": 1.42055011
 			    },
-			    "Nickname": "{{ slotLabel|raw }}",
+			    "Nickname": "{{ slotLabel|raw|replace({"\"":"\\\""}) }}",
 			    "Description": "{% if slot.dice == 2 and slot.card.deckLimit == 1 %}elite {% endif %}{{slot.card.set.code}} {{slot.card.position}}",
 			    "ColorDiffuse": {
 			      "r": 0.713235259,
@@ -326,7 +326,7 @@
 			            "scaleY": 1.0,
 			            "scaleZ": 1.42055011
 			          },
-			          "Nickname": "{{ slotLabel|raw }}",
+			          "Nickname": "{{ slotLabel|raw|replace({"\"":"\\\""}) }}",
 			          "Description": "{{slot.card.set.code}} {{slot.card.position}}",
 			          "ColorDiffuse": {
 			            "r": 0.713235259,


### PR DESCRIPTION
This may only be an issue for "Fair" Trade at present, but this change should allow strings with double quotes to generate a backslash in JSON.  Otherwise, the JSON formatting breaks because a plain double quote gets written.