### PR TITLE
Feature : Banned and errata'd data for each format

### DIFF
--- a/src/AppBundle/Resources/public/hbs/deck-layout-standard-09114.handlebars
+++ b/src/AppBundle/Resources/public/hbs/deck-layout-standard-09114.handlebars
@@ -96,6 +96,9 @@
 							{{#if (restricted code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
+							{{#if (errata code)}}
+		                    	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+		                    {{/if}}
 						</div>
 						<div class="character-dice">
 							{{indeck.dice}} <span class="icon-die"></span>
@@ -130,6 +133,9 @@
                     {{#if (restricted code)}}
                     	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                     {{/if}}
+					{{#if (errata code)}}
+                    	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+                    {{/if}}
 				</div>
 				{{/each}}
 				{{/with}}
@@ -162,6 +168,9 @@
                    {{#if (restricted code)}}
                    <span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                    {{/if}}
+				   {{#if (errata code)}}
+					   <span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+				   {{/if}}
 				</div>
 				{{/each}}
 				{{/with}}

--- a/src/AppBundle/Resources/public/hbs/deck-layout-standard.handlebars
+++ b/src/AppBundle/Resources/public/hbs/deck-layout-standard.handlebars
@@ -94,6 +94,9 @@
 							{{#if (restricted code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
+							{{#if (errata code)}}
+		                    	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+		                    {{/if}}
 						</div>
 						<div class="character-dice">
 							{{indeck.dice}} <span class="icon-die"></span>
@@ -130,6 +133,9 @@
                    {{#if (restricted code)}}
                    <span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                    {{/if}}
+				   {{#if (errata code)}}
+					   <span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+				   {{/if}}
 				</div>
 				{{/each}}
 				{{/with}}

--- a/src/AppBundle/Resources/public/hbs/ui_card-legality.handlebars
+++ b/src/AppBundle/Resources/public/hbs/ui_card-legality.handlebars
@@ -10,7 +10,15 @@
 		<tr>
 			{{#each formats as |format formatId|}}
 			<td class="text-center fg-{{../card.faction_code}} {{#unless (legal ../card.code format.code)}}no-{{/unless}}legal">
-				<span class="fa fa-lg {{ternary (legal ../card.code format.code) 'fa-check-circle' 'fa-ban'}}"></span>
+			    {{#if (errata ../card.code format.code)}}
+					<span class="fa fa-lg fa-exclamation-triangle" data-toggle="tooltip" title="{{trans 'card.format.errata'}}"></span>
+				{{else}}
+					{{#if (banned ../card.code format.code)}}
+						<span class="fa fa-lg fa-times-circle" data-toggle="tooltip" title="{{trans 'card.format.banned'}}"></span>
+					{{else}}
+						<span class="fa fa-lg {{ternary (legal ../card.code format.code) 'fa-check-circle' 'fa-ban'}}"></span>
+					{{/if}}
+				{{/if}}
 			</td>
 			{{/each}}
 		</tr>

--- a/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
+++ b/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
@@ -20,6 +20,9 @@
         {{#if (restricted card.code)}}
         <span class="fa fa-exclamation text-danger" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
         {{/if}}
+		{{#if (errata card.code)}}
+        <span class="fa fa-exclamation text-danger" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
+        {{/if}}
     </td>
     <td> 
         <a class="card card-tip" data-code="{{ card.code }}" href="{{ url }}" data-target="#cardModal" data-remote="false" data-toggle="modal">

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -54,6 +54,10 @@ Handlebars.registerHelper('restricted', function(code) {
 	return _.includes(app.deck.get_format_data().data.restricted, code);
 });	
 
+Handlebars.registerHelper('errata', function(code) {
+	return _.includes(app.deck.get_format_data().data.errata, code);
+});	
+
 /*
  * Templates for the deck layout
  */

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -731,6 +731,9 @@ deck.can_include_card = function can_include_card(card) {
 	// card not valid in format
 	if(!deck.within_format_sets(card)) return false;
 
+	// banned card
+	if(_.includes(app.deck.get_format_data().data.banned, card.code)) return false;
+
 	// neutral card => yes
 	if(card.affiliation_code === 'neutral') return true;
 

--- a/src/AppBundle/Resources/public/js/handlebars-helpers.js
+++ b/src/AppBundle/Resources/public/js/handlebars-helpers.js
@@ -91,7 +91,11 @@
         if(app.data && app.data.formats && app.data.cards) {
             var card = app.data.cards.findById(card_code);
             var format = app.data.formats.findById(format_code);
-
+			
+			//if card has been banned in this format
+			if(_.includes(format.data.banned, card_code))
+				return false;
+				
             //if card's set included in legal sets of the format
             if(_.includes(format.data.sets, card.set_code))
                 return true;
@@ -118,6 +122,30 @@
         
         return false;
     });
+	
+	Handlebars.registerHelper('errata', function(card_code, format_code) {
+		if(arguments < 2)
+			throw new Error("Handlerbars Helper 'errata' needs 2 parameters");
+
+		if(app.data && app.data.formats) {
+			var format = app.data.formats.findById(format_code);
+			return _.includes(format.data.errata, card_code);
+		}
+
+		return false;
+	});
+	
+	Handlebars.registerHelper('banned', function(card_code, format_code) {
+		if(arguments < 2)
+			throw new Error("Handlerbars Helper 'banned' needs 2 parameters");
+
+		if(app.data && app.data.formats) {
+			var format = app.data.formats.findById(format_code);
+			return _.includes(format.data.banned, card_code);
+		}
+
+		return false;
+	});
 
     Handlebars.registerHelper('balance', function(card_code, format_code) {
         if(arguments < 2)

--- a/src/AppBundle/Resources/public/js/ui.card.js
+++ b/src/AppBundle/Resources/public/js/ui.card.js
@@ -10,6 +10,7 @@
 				card: app.data.cards.findById(code),
 				formats: app.data.formats.find({})
 			}));
+			$table.find('[data-toggle="tooltip"]').tooltip();
 		});
 	}
 

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -11,6 +11,10 @@ Handlebars.registerHelper('restricted', function(code) {
 	return _.includes(app.deck.get_format_data().data.restricted, code);
 });	
 
+Handlebars.registerHelper('errata', function(code) {
+	return _.includes(app.deck.get_format_data().data.errata, code);
+});	
+
 /**
  * reads ui configuration from localStorage
  * @memberOf ui


### PR DESCRIPTION
This feature allow two new status for cards regarding the chosen deck format :

1) The card have been banned in the format. When checking the details about the card, it appears as a red background with a new kind of forbidden icon... And a tooltip to make things clearer. When building a deck, the card is simply considered as an illegal card (grayed and striked).
<img width="493" alt="Capture d’écran 2020-12-19 à 13 26 30" src="https://user-images.githubusercontent.com/3064433/102689390-f5205400-41fd-11eb-9e92-d48e580ca604.png">


2) The card have been errated in the format. The goal is to allow a fan-made format to indicated a card text have been errata'd but only for its own format. It appears with a warning when looking at the card, and yet a tooltip to make things clear. When building a deck, the card appears with an exclamation point in the availability list and in the deck list. The same as for the restricted list, but with an appropriate tooltip.
<img width="469" alt="Capture d’écran 2020-12-19 à 13 30 11" src="https://user-images.githubusercontent.com/3064433/102689450-82fc3f00-41fe-11eb-8ceb-0d61fc36f544.png">


This way, the card text in SWDB should only be modified and pointed with `has_errata = true` if the card have been errated in all formats. The errata itself must be checked in the corresponding Holocron but... It seems me the cleanest way to do it.


To work properly, this PR will need : 
- The [corresponding PR](https://github.com/fafranco82/swdestinydb-json-data/pull/287) for format new data on the data repository.
- The new translation : `card.format.banned` = `The card has been banned in this format`
- The new translation : `card.format.errata` = `The card has been errata'd in this specific format`

