### PR TITLE
Feature : non-unique elite characters dices

### DIFF
--- a/app/DoctrineMigrations/Version20201205083907.php
+++ b/app/DoctrineMigrations/Version20201205083907.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20201205083907 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE deckslot ADD dices VARCHAR(20) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE deckslot DROP COLUMN dices');
+    }
+}

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -648,6 +648,7 @@ class BuilderController extends Controller
                     $info = $this->get('cards_data')->getCardInfo($character->getCard(), false);
                     $info['qty'] = $character->getQuantity();
                     $info['dice'] = $character->getDice();
+                    $info['dices'] = $character->getDices();
                     $characters[] = $info;
                 }
 

--- a/src/AppBundle/Entity/Deckslot.php
+++ b/src/AppBundle/Entity/Deckslot.php
@@ -107,6 +107,7 @@ class Deckslot implements \AppBundle\Model\SlotInterface
     {
         return $this->card;
     }
+	
     /**
      * @var integer
      */
@@ -136,4 +137,33 @@ class Deckslot implements \AppBundle\Model\SlotInterface
     {
         return $this->dice;
     }
+	
+	/**
+	 * @var string
+	 */
+	private $dices;
+
+	/**
+	 * Set dices
+	 *
+	 * @param string $dices
+	 *
+	 * @return Deckslot
+	 */
+	public function setDices($dices)
+	{
+		$this->dices = $dices;
+
+		return $this;
+	}
+
+	/**
+	 * Get dices
+	 *
+	 * @return string
+	 */
+	public function getDices()
+	{
+		return $this->dices;
+	}
 }

--- a/src/AppBundle/Model/DecklistFactory.php
+++ b/src/AppBundle/Model/DecklistFactory.php
@@ -74,6 +74,7 @@ class DecklistFactory
 			$decklistslot->setCard($slot->getCard());
 			$decklistslot->setQuantity($slot->getQuantity());
 			$decklistslot->setDice($slot->getDice());
+			$decklistslot->setDices($slot->getDices());
 			$decklistslot->setDecklist($decklist);
 			$decklist->getSlots()->add($decklistslot);
 		}

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -253,7 +253,14 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
 			}
 
 			$inc = 0;
-			if($card->getIsUnique())
+			if($slot instanceof Deckslot && $slot->getDices()) {
+				
+				foreach(explode(",", $slot->getDices()) as $i) {
+					$pointValues = preg_split('/\//', $formatPoints);
+					$inc += intval($pointValues[$i-1], 10);
+				}
+			}
+			else if($card->getIsUnique())
 			{
 				$pointValues = preg_split('/\//', $formatPoints);
 				$inc = intval($pointValues[$slot->getDice()-1], 10);

--- a/src/AppBundle/Resources/config/doctrine/Deckslot.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Deckslot.orm.yml
@@ -25,3 +25,6 @@ AppBundle\Entity\Deckslot:
             type: smallint
         dice:
             type: smallint
+        dices:
+            type: string
+            length: 20

--- a/src/AppBundle/Resources/public/hbs/card_modal-options.handlebars
+++ b/src/AppBundle/Resources/public/hbs/card_modal-options.handlebars
@@ -1,15 +1,43 @@
-<div class="btn-group" data-toggle="buttons">
-	{{#range 0 card.maxqty.cards inclusive=true}}
-	<label class="btn btn-xs btn-default{{#compare this ../card.indeck.cards}} active{{/compare}}">
-		<input type="radio" name="qty-{{../card.code}}" value="{{this}}"/>
-		{{this}}
-	</label>
-	{{/range}}
-</div>
-{{#if second_die}} 
-<div class="btn-group" data-toggle="buttons">
-	<label class="btn btn-default btn-xs">
-		<input type="checkbox" name="2nd-{{card.code}}" value="2"/>2 <span class="icon-die"></span>
-	</label>
-</div>
+{{#if multiple_copies}}
+
+	{{#each card.indeck.dices}}
+		<div class="btn-group" data-toggle="buttons">
+			<label class="btn btn-xs btn-default{{#compare 0 this}} active{{/compare}}">
+				<input type="radio" name="{{../prefix}}-qty-{{../card.code}}-{{@index}}" value="0" /> 0
+			</label>
+			<label class="btn btn-xs btn-default{{#compare 1 this}} active{{/compare}}">
+				<input type="radio" name="{{../prefix}}-qty-{{../card.code}}-{{@index}}" value="1" /> 1
+			</label>
+			<label class="btn btn-xs btn-default{{#compare 2 this}} active{{/compare}}">
+				<input type="radio" name="{{../prefix}}-qty-{{../card.code}}-{{@index}}" value="2" /> 2 <span class="icon-die"></span>
+			</label>
+		</div>
+	{{/each}}
+
+{{else if unique_character}}
+
+	<div class="btn-group" data-toggle="buttons">
+		{{#range 0 card.maxqty.dice inclusive=false}}
+		<label class="btn btn-xs btn-default{{#compare this ../card.indeck.dice}} active{{/compare}}">
+			<input type="radio" name="{{../prefix}}-qty-{{../card.code}}" value="{{this}}"/>
+			{{this}}
+		</label>
+		{{/range}}
+		<label class="btn btn-xs btn-default{{#compare card.maxqty.dice card.indeck.dice}} active{{/compare}}">
+			<input type="radio" name="{{../prefix}}-qty-{{card.code}}" value="{{card.maxqty.dice}}"/>
+			{{card.maxqty.dice}} <span class="icon-die"></span>
+		</label>
+	</div>
+
+{{else}}
+
+	<div class="btn-group" data-toggle="buttons">
+		{{#range 0 card.maxqty.cards inclusive=true}}
+		<label class="btn btn-xs btn-default{{#compare this ../card.indeck.cards}} active{{/compare}}">
+			<input type="radio" name="{{../prefix}}-qty-{{../card.code}}" value="{{this}}"/>
+			{{this}}
+		</label>
+		{{/range}}
+	</div>
+
 {{/if}}

--- a/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
+++ b/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
@@ -1,20 +1,6 @@
 <tr data-code="{{card.code}}"> 
     <td>
-        <div class="btn-group" data-toggle="buttons">
-        	{{#range 0 card.maxqty.cards inclusive=true}}
-        	<label class="btn btn-xs btn-default{{#compare this ../card.indeck.cards}} active{{/compare}}">
-        		<input type="radio" name="qty-{{../card.code}}" value="{{this}}"/>
-        		{{this}}
-        	</label>
-        	{{/range}}
-        </div>
-        {{#if second_die}}
-        <div class="btn-group" data-toggle="buttons">
-        	<label class="btn btn-default btn-xs">
-        		<input type="checkbox" name="2nd-{{card.code}}" value="2"/>2 <span class="icon-die"></span>
-        	</label>
-        </div>
-        {{/if}}
+        {{{qty_options}}}
     </td>
     <td>
         {{#if (restricted card.code)}}

--- a/src/AppBundle/Resources/public/js/app.card_modal.js
+++ b/src/AppBundle/Resources/public/js/app.card_modal.js
@@ -21,7 +21,6 @@ card_modal.typeahead = function typeahead(event, card) {
 
 var NameTemplate = Handlebars.templates['card_modal-name'];
 var InfoTemplate = Handlebars.templates['card_modal-info'];
-var OptionsTemplate = Handlebars.templates['card_modal-options'];
 
 function fill_modal (code) {
 	var card = app.data.cards.findById(code),
@@ -37,22 +36,7 @@ function fill_modal (code) {
 
 	var qtyelt = modal.find('.modal-qty');
 	if(qtyelt) {
-
-		qtyelt.html(OptionsTemplate({
-			card: card,
-			second_die: card.type_code=='character' && card.is_unique && card.maxqty.dice > 1
-		}));
-
-		qtyelt.find('input[name="2nd-' + card.code + '"]').each(function(i, element) {
-			// if that switch is NOT the one with the new quantity, uncheck it
-			// else, check it
-			if($(element).val() != card.indeck.dice) {
-				$(element).prop('checked', false).closest('label').removeClass('active');
-			} else {
-				$(element).prop('checked', true).closest('label').addClass('active');
-			}
-		});
-
+		qtyelt.html(app.ui.build_quantity_options(card, 'modal'));
 	} else {
 		if(qtyelt) qtyelt.closest('.row').remove();
 	}

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -278,7 +278,12 @@ deck.get_character_deck = function get_character_deck(sort) {
  */
 deck.get_character_points = function get_character_points() {
 	var points = _.reduce(deck.get_character_deck(), function(points, character) {
-		if(character.is_unique) {
+		if(character.indeck.dices) {
+			for(var i=0;i<character.indeck.dices.length;i++) {
+				points += parseInt(character.points.split('/')[character.indeck.dices[i]-1], 10);
+			}
+			return points;
+		} else if(character.is_unique) {
 			return points + parseInt(character.points.split('/')[character.indeck.dice-1], 10);
 		} else {
 			return points + parseInt(character.points, 10) * character.indeck.cards;

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -44,9 +44,7 @@ Handlebars.registerHelper('own_enough_dice', function(card, options) {
 });
 
 Handlebars.registerHelper('subtype', function(card, subtype_code, options) {
-	console.log(subtype_code);
 	var subtype = _.find(card.subtypes, {code: subtype_code});
-	console.log(subtype);
 	return subtype && subtype.name; 
 });
 
@@ -115,7 +113,8 @@ deck.set_slots = function set_slots(slots) {
 			app.data.cards.updateById(code, {
 				indeck: {
 					cards: slots[code].quantity,
-					dice: slots[code].dice
+					dice: slots[code].dice,
+					dices: (slots[code].dices ? slots[code].dices.split(',').map(Number) : null)
 				}
 			});
 		}
@@ -324,6 +323,18 @@ deck.get_character_row_data = function get_character_row_data() {
 	return _.flatten(_.map(deck.get_character_deck(), function(card) {
 		if(card.is_unique) {
 			return card;
+		} else if(card.indeck.dices) {
+			var spread = [];
+			for(var i=0;i<card.indeck.dices.length;i++) {
+				var clone = _.clone(card);
+				clone.indeck = {
+					cards: 1,
+					dice: card.indeck.dices[i]
+				};
+				clone.original = card;
+				spread.push(clone);
+			}
+			return spread;
 		} else {
 			var spread = [];
 			for(var i=0;i<card.indeck.cards;i++) {
@@ -464,7 +475,7 @@ deck.display = function display(container, options) {
  * @memberOf deck
  * @return boolean true if at least one other card quantity was updated
  */
-deck.set_card_copies = function set_card_copies(card_code, nb_copies) {
+deck.set_card_copies = function set_card_copies(card_code, nb_copies, dices) {
 	var card = app.data.cards.findById(card_code);
 	if(!card) return false;
 
@@ -494,12 +505,15 @@ deck.set_card_copies = function set_card_copies(card_code, nb_copies) {
 	// except for unique characters when you can only hava a copy, but one
 	// or more dice. Still then, the UI only allow you to select one copy,
 	// so if 1 copy is selected for a unique character, 1 die is selected also.
+	// Dices : Manage elite non-unique characters by allowing multiple copies of them
 	app.data.cards.updateById(card_code, {
 		indeck: {
-			cards: nb_copies,
-			dice: card.has_die ? nb_copies : 0
+			cards: dices ? dices.length : nb_copies,
+			dice: dices ? dices.length : (card.has_die ? nb_copies : 0),
+			dices: dices
 		}
 	});
+	
 	app.deck_history && app.deck_history.notify_change();
 
 	//list of cards which, by rules, deny or allow some cards, or modify cards' max quantity
@@ -546,7 +560,8 @@ deck.get_content = function get_content() {
 	cards.forEach(function (card) {
 		content[card.code] = {
 			quantity: card.indeck.cards,
-			dice: card.indeck.dice
+			dice: card.indeck.dice,
+			dices: (card.indeck.dices ? card.indeck.dices.join(',') : null)
 		};
 	});
 	return content;

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -82,7 +82,7 @@ ui.set_max_qty = function set_max_qty() {
 			dice: record.has_die ? max_value : 0
 		}
 
-		if(record.type_code=='character' && record.is_unique) {
+		if(record.type_code=='character') {
 			max_qty.dice = record.points.split('/').length;
 		}
 
@@ -358,18 +358,24 @@ ui.on_list_quantity_change = function on_list_quantity_change(event) {
 	var row = $(this).closest('.card-container');
 	var code = row.data('code');
 	var quantity = parseInt($(this).val(), 10);
-	ui.on_quantity_change(code, quantity);
-}
-
-/**
- * @memberOf ui
- * @param event
- */
-ui.on_list_2nd_die_toggle = function on_list_2nd_die_toggle(event) {
-	var row = $(this).closest('.card-container');
-	var code = row.data('code');
-	var active = $(this).prop('checked');
-	ui.on_2nd_die_change(code, active);
+	
+	var dices;
+	if($('input[name=list-qty-'+code+'-0]').length) {
+		dices = [];
+		for(var i = 0; i < 10; i++) {
+			if(!$('input[name=list-qty-'+code+'-'+i+']').length) {
+				break;
+			}
+			if($('label.active input[name=list-qty-'+code+'-'+i+']').length) {
+				var qty = parseInt($('label.active input[name=list-qty-'+code+'-'+i+']').val());
+				if(qty > 0) {
+					dices.push(qty);
+				}
+			}
+		}
+	}
+	
+	ui.on_quantity_change(code, quantity, dices);
 }
 
 /**
@@ -380,25 +386,25 @@ ui.on_modal_quantity_change = function on_modal_quantity_change(event) {
 	var modal = $('#cardModal');
 	var code =  modal.data('code');
 	var quantity = parseInt($(this).val(), 10);
+	
+	var dices;
+	if($('input[name=modal-qty-'+code+'-0]').length) {
+		dices = [];
+		for(var i = 0; i < 10; i++) {
+			if(!$('input[name=modal-qty-'+code+'-'+i+']').length) {
+				break;
+			}
+			if($('label.active input[name=modal-qty-'+code+'-'+i+']').length) {
+				var qty = parseInt($('label.active input[name=modal-qty-'+code+'-'+i+']').val());
+				if(qty > 0) {
+					dices.push(qty);
+				}
+			}
+		}
+	}
+	
 	modal.modal('hide');
-	ui.on_quantity_change(code, quantity);
-
-	setTimeout(function () {
-		$('#filter-text').typeahead('val', '').focus();
-	}, 100);
-}
-
-
-/**
- * @memberOf ui
- * @param event
- */
-ui.on_modal_2nd_die_toggle = function on_modal_2nd_die_toggle(event) {
-	var modal = $('#cardModal');
-	var code =  modal.data('code');
-	var active = $(this).prop('checked');
-	modal.modal('hide');
-	ui.on_2nd_die_change(code, active);
+	ui.on_quantity_change(code, quantity, dices);
 
 	setTimeout(function () {
 		$('#filter-text').typeahead('val', '').focus();
@@ -417,32 +423,25 @@ ui.refresh_row = function refresh_row(card_code) {
 
 		// rows[card_code] is the card row of our card
 		// for each "quantity switch" on that row
-		row.find('input[name="qty-' + card_code + '"]').each(function(i, element) {
-			// if that switch is NOT the one with the new quantity, uncheck it
-			// else, check it
-			if($(element).val() != quantity) {
-				$(element).prop('checked', false).closest('label').removeClass('active');
-			} else {
-				$(element).prop('checked', true).closest('label').addClass('active');
-			}
-		});
-		row.find('input[name="2nd-' + card_code + '"]').each(function(i, element) {
-			// if that switch is NOT the one with the new quantity, uncheck it
-			// else, check it
-			if($(element).val() != dice) {
-				$(element).prop('checked', false).closest('label').removeClass('active');
-			} else {
-				$(element).prop('checked', true).closest('label').addClass('active');
-			}
-		});
+		for(var i=0; i < card.maxqty.cards; i++) {
+			row.find('input[name="qty-' + i + '-' + card_code + '"]').each(function(i, element) {
+				// if that switch is NOT the one with the new quantity, uncheck it
+				// else, check it
+				if($(element).val() != quantity) {
+					$(element).prop('checked', false).closest('label').removeClass('active');
+				} else {
+					$(element).prop('checked', true).closest('label').addClass('active');
+				}
+			});
+		}
 	});
 }
 
 /**
  * @memberOf ui
  */
-ui.on_quantity_change = function on_quantity_change(card_code, quantity) {
-	var update_all = app.deck.set_card_copies(card_code, quantity);
+ui.on_quantity_change = function on_quantity_change(card_code, quantity, dices) {
+	var update_all = app.deck.set_card_copies(card_code, quantity, dices);
 	ui.refresh_deck();
 
 	//if one of the following or was selected or unselected...
@@ -454,20 +453,6 @@ ui.on_quantity_change = function on_quantity_change(card_code, quantity) {
 
 	if(update_all) {
 		ui.refresh_list(_.includes(['08143', '09114'], card_code));
-	}
-	else {
-		ui.refresh_row(card_code);
-	}
-}
-/**
- * @memberOf ui
- */
-ui.on_2nd_die_change = function on_2nd_die_change(card_code, active) {
-	var update_all = !!(app.deck.set_card_copies(card_code, 1) + app.deck.set_card_dice(card_code, active ? 2 : 1));
-	ui.refresh_deck();
-
-	if(update_all) {
-		ui.refresh_list();
 	}
 	else {
 		ui.refresh_row(card_code);
@@ -516,14 +501,12 @@ ui.setup_event_handlers = function setup_event_handlers() {
 
 	$('#config-options').on('change', 'input', ui.on_config_change);
 	$('#collection').on('change', 'input[type=radio]', ui.on_list_quantity_change);
-	$('#collection').on('change', 'input[type=checkbox]', ui.on_list_2nd_die_toggle);
 
 	$('#cardModal').on('keypress', function(event) {
 		var num = parseInt(event.which, 10) - 48;
 		$('#cardModal input[type=radio][value=' + num + ']').trigger('change');
 	});
 	$('#cardModal').on('change', 'input[type=radio]', ui.on_modal_quantity_change);
-	$('#cardModal').on('change', 'input[type=checkbox]', ui.on_modal_2nd_die_toggle);
 	$('thead').on('click', 'a[data-sort]', ui.on_table_sort_click);
 
 }
@@ -561,28 +544,42 @@ ui.update_list_template = function update_list_template() {
 	DisplayColumnsTpl = Handlebars.templates['ui_deckedit-display-'+Config['display-column']+'columns'];
 }
 
+var OptionsTemplate = Handlebars.templates['card_modal-options'];
+
+ui.build_quantity_options = function build_quantity_options(card, prefix) {
+	
+	var multiple_copies = (card.type_code == 'character' && !card.is_unique && card.maxqty.dice > 1);
+	if(multiple_copies) {
+		if(!card.indeck.dices) {
+			card.indeck.dices = [];
+			for(var i = 0; i < card.maxqty.cards; i++) {
+				// Will provide some kind of retro-compatibility
+				card.indeck.dices.push(i < card.indeck.cards ? 1 : 0);
+			}
+		} else {
+			for(var i = card.indeck.dices.length; i < card.maxqty.cards; i++) {
+				card.indeck.dices.push(0);
+			}
+		}
+	}
+
+	return OptionsTemplate({
+		card: card,
+		prefix: prefix,
+		unique_character: (card.type_code == 'character' && card.is_unique),
+		multiple_copies: multiple_copies
+	});
+}
+
 /**
  * builds a row for the list of available cards
  * @memberOf ui
  */
 ui.build_row = function build_row(card) {
-	var radios = '', radioTpl = _.template(
-		'<label class="btn btn-xs btn-default <%= active %>"><input type="radio" name="qty-<%= card.code %>" value="<%= i %>"><%= i %></label>'
-	);
-
-	for (var i = 0; i <= card.maxqty.cards; i++) {
-		radios += radioTpl({
-			i: i,
-			active: (i == card.indeck.cards ? ' active' : ''),
-			card: card
-		});
-	}
-
 	var html = DisplayColumnsTpl({
-		radios: radios,
+		qty_options: ui.build_quantity_options(card, 'list'),
 		url: Routing.generate('cards_zoom', {card_code:card.code}),
 		card: card,
-		second_die: card.type_code=='character' && card.is_unique && card.maxqty.dice > 1
 	});
 	return $(html);
 }
@@ -629,24 +626,15 @@ ui.refresh_list = _.debounce(function refresh_list(refresh) {
 
 		row.find('[data-toggle="tooltip"]').tooltip();
 
-		row.find('input[name="qty-' + card.code + '"]').each(
-			function(i, element) {
+		for(var i=0; i < card.maxqty.cards; i++) {
+			row.find('input[name="qty-' + i + '-' + card.code + '"]').each(function(i, element) {
 				if($(element).val() == card.indeck.cards) {
 					$(element).prop('checked', true).closest('label').addClass('active');
 				} else {
 					$(element).prop('checked', false).closest('label').removeClass('active');
 				}
-			}
-		);
-		row.find('input[name="2nd-' + card.code + '"]').each(function(i, element) {
-			// if that switch is NOT the one with the new quantity, uncheck it
-			// else, check it
-			if($(element).val() != card.indeck.dice) {
-				$(element).prop('checked', false).closest('label').removeClass('active');
-			} else {
-				$(element).prop('checked', true).closest('label').addClass('active');
-			}
-		});
+			});
+		}
 
 		if (unusable) {
 			row.find('label').addClass("disabled").find('input[type=radio]').prop("disabled", true);

--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -162,7 +162,6 @@
 				{# Characters #}
 				{% for slot in deck.slots_by_type.character %}
 				{% set slotLabel = slot.card.name~(slot.card.subtitle is defined and slot.card.subtitle != "" ? ", "~slot.card.subtitle : "")%}
-				{% for i in range (1, min(slot.dice,slot.card.deckLimit)) %}
 				{
 			    "Name": "Card",
 			    "Transform": {
@@ -177,7 +176,7 @@
 			      "scaleZ": 1.42055011
 			    },
 			    "Nickname": "{{ slotLabel|replace({"\"":"\\\""})|raw }}",
-			    "Description": "{% if slot.dice == 2 and slot.card.deckLimit == 1 %}elite {% endif %}{{slot.card.set.code}} {{slot.card.position}}",
+			    "Description": "{% if slot.dice == 2 %}elite {% endif %}{{slot.card.set.code}} {{slot.card.position}}",
 			    "ColorDiffuse": {
 			      "r": 0.713235259,
 			      "g": 0.713235259,
@@ -217,7 +216,6 @@
 					"GUID": "{{ deck.guidArray[guidCount] }}"
 					{% set guidCount = guidCount + 1 %}
 			  },
-				{% endfor %}
 				{% endfor %}
 				{# Deck of Other Cards #}
 				{

--- a/src/AppBundle/Services/Decks.php
+++ b/src/AppBundle/Services/Decks.php
@@ -128,11 +128,13 @@ class Decks
 		foreach ($content as $card_code => $qtys) {
 			$qty = $qtys['quantity'];
 			$dice = $qtys['dice'];
+			$dices = $qtys['dices'];
 			
 			$card = $cards[$card_code];
 			$slot = new Deckslot();
 			$slot->setQuantity($qty);
 			$slot->setDice($dice);
+			$slot->setDices($dices);
 			$slot->setCard($card);
 			$slot->setDeck($deck);
 			$deck->addSlot($slot);


### PR DESCRIPTION
This PR allows to manage correctly the non-unique elite characters, allowing to choose between a combinations of elite and non elite of those characters. First, here is how it appears with this PR.

_In the deckbuild list :_ 
<img width="584" alt="Capture d’écran 2020-12-19 à 16 28 34" src="https://user-images.githubusercontent.com/3064433/102692964-615b8180-4217-11eb-9a27-357989e97c4b.png">


_In the deckbuild modal :_ 
<img width="539" alt="Capture d’écran 2020-12-19 à 16 29 14" src="https://user-images.githubusercontent.com/3064433/102692965-628cae80-4217-11eb-90eb-3cb4cf54d35e.png">



How do I manage it? There is a **Doctrine migration** adding a "dices" fields to a deckslot. The goal of this field is to contain an array of integers, each representing one instance of dices for a non unique elite characters. Each time it is needed, this new field is used instead of the "dice" one. Maybe it's not the cleanest solution but I wanted to keep it simple. The dices kind-of checkboxes are now the same template in the deckbuild list and in the modal.

It also therefore refactor other type of diced characters, not using anymore the "2nd" quantity field but a more generic way, allowing for example a third dice on a character.

It's not yet perfect in terms of UI but it's a huge step. We are using it since more than two weeks with our playtesters on our own swdestinydb instance and it seems ok for most situation. It also works with TTS deck export. I'll try to follow any bug related to this.



(Fixes #297) 