### PR TITLE
Feature : Make fanmade set to be part of a project

### DIFF
--- a/app/DoctrineMigrations/Version20201014115215.php
+++ b/app/DoctrineMigrations/Version20201014115215.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20201014115215 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE cardset ADD project_name VARCHAR(50) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE cardset DROP COLUMN project_name');
+    }
+}

--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -397,7 +397,8 @@ class ImportStdCommand extends ContainerAwareCommand
 					'size', 
 					'cgdb_id_start',
 					'cgdb_id_end',
-					'date_release'
+					'date_release',
+					'project_name'
 			], [
 				'cycle_code'
 			], []);

--- a/src/AppBundle/Entity/Set.php
+++ b/src/AppBundle/Entity/Set.php
@@ -13,7 +13,8 @@ class Set implements \Gedmo\Translatable\Translatable, \Serializable
                 'position' => $this->position,
                 'cgdb_id_start' => $this->cgdbIdStart,
                 'cgdb_id_end' => $this->cgdbIdEnd,
-                'size' => $this->size
+                'size' => $this->size,
+				'project_name' => $this->projectName
         ];
     }
     
@@ -44,6 +45,11 @@ class Set implements \Gedmo\Translatable\Translatable, \Serializable
      * @var string
      */
     private $code;
+
+	/**
+     * @var string
+     */
+    private $projectName;
 
     /**
      * @var string
@@ -141,6 +147,30 @@ class Set implements \Gedmo\Translatable\Translatable, \Serializable
     public function getCode()
     {
         return $this->code;
+    }
+
+    /**
+     * Set project name
+     *
+     * @param string $projectName
+     *
+     * @return Set
+     */
+    public function setProjectName($projectName)
+    {
+        $this->projectName = $projectName;
+
+        return $this;
+    }
+
+    /**
+     * Get project name
+     *
+     * @return string
+     */
+    public function getProjectName()
+    {
+        return $this->projectName;
     }
 
     /**

--- a/src/AppBundle/Resources/config/doctrine/Set.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Set.orm.yml
@@ -31,6 +31,11 @@ AppBundle\Entity\Set:
             type: string
             length: 255
             nullable: false
+        projectName:
+            type: string
+            length: 50
+            nullable: true
+            column: project_name
         name:
             type: string
             length: 1024

--- a/src/AppBundle/Resources/public/css/bootstrap-essentials.css
+++ b/src/AppBundle/Resources/public/css/bootstrap-essentials.css
@@ -1,0 +1,3428 @@
+@charset "UTF-8";
+.page-content {
+  margin-bottom: 0;
+  border: none;
+  border-radius: 0;
+}
+
+.page-sidebar + .page-content,
+.page-content + .page-sidebar,
+.page-sidebar-right + .page-content {
+  padding: .1px;
+}
+
+.page-main {
+  height: auto;
+  overflow: hidden;
+}
+.page-main .page-content {
+  width: auto;
+  overflow: hidden;
+}
+.page-main .page-sidebar {
+  float: left;
+  width: 240px;
+}
+.page-main .page-sidebar-right {
+  float: right;
+  width: 240px;
+}
+@media (min-width: 768px) {
+  .page-main .page-sidebar.offcanvas-xs {
+    position: relative;
+    border-width: 1px;
+    border-radius: 4px;
+  }
+}
+@media (min-width: 992px) {
+  .page-main .page-sidebar.offcanvas-sm {
+    position: relative;
+    border-width: 1px;
+    border-radius: 4px;
+  }
+}
+@media (min-width: 1200px) {
+  .page-main .page-sidebar.offcanvas-md {
+    position: relative;
+    border-width: 1px;
+    border-radius: 4px;
+  }
+}
+.page-main.fixed-width-right {
+  padding-right: 240px;
+}
+@media (max-width: 767px) {
+  .page-main.fixed-width-right {
+    padding-right: 0;
+  }
+}
+.page-main.fixed-width-right .page-content {
+  float: left;
+  width: 100%;
+}
+.page-main.fixed-width-right .page-sidebar {
+  float: right;
+  margin-right: -240px;
+}
+@media (max-width: 767px) {
+  .page-main.fixed-width-right .page-content,
+  .page-main.fixed-width-right .page-sidebar {
+    float: left;
+    width: 100%;
+    margin: 0;
+  }
+}
+
+/* Tabs */
+@media (max-width: 767px) {
+  .nav-justified-xs {
+    width: 100%;
+  }
+  .nav-justified-xs > li {
+    display: table-cell;
+    float: none !important;
+    width: 1%;
+    text-align: center;
+  }
+  .nav-justified-xs > li > a {
+    margin-bottom: -1px;
+  }
+}
+.nav-tabs > li {
+  float: left;
+  margin-bottom: -1px;
+}
+.nav-tabs > li a:hover {
+  border-color: transparent;
+}
+
+.tab-content > .tab-pane .panel-body {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.tabs-left > .nav-tabs,
+.tabs-right > .nav-tabs {
+  width: 20%;
+  border-bottom: 0;
+}
+.tabs-left > .nav-tabs > li,
+.tabs-right > .nav-tabs > li {
+  float: none;
+}
+.tabs-left > .nav-tabs > li > a,
+.tabs-right > .nav-tabs > li > a {
+  min-width: 74px;
+  margin-right: 0;
+  margin-bottom: 3px;
+}
+
+.tab-content > .tab-pane,
+.pill-content > .pill-pane {
+  display: none;
+}
+
+.tab-content > .active,
+.pill-content > .active {
+  display: block;
+}
+
+.tabs-left .panel-body {
+  position: static;
+  width: 80%;
+  margin-left: 20%;
+  border-left: 1px solid #ddd;
+}
+.tabs-left > .nav-tabs {
+  float: left;
+  margin-right: 19px;
+}
+@media (max-width: 368px) {
+  .tabs-left > .nav-tabs {
+    margin-left: -15px;
+  }
+}
+.tabs-left > .nav-tabs > li > a {
+  margin-right: -1px;
+  border-radius: 4px 0 0 4px;
+}
+.tabs-left > .nav-tabs .active > a, .tabs-left > .nav-tabs .active > a:hover, .tabs-left > .nav-tabs .active > a:focus {
+  border-color: #ddd transparent #ddd #ddd;
+}
+
+.tabs-right .panel-body {
+  width: 80%;
+  margin-right: 20%;
+  border-right: 1px solid #ddd;
+}
+
+.tabs-right > .nav-tabs {
+  float: right;
+  margin-left: 19px;
+}
+
+.tabs-right > .nav-tabs > li > a {
+  margin-left: -1px;
+  border-radius: 0 4px 4px 0;
+}
+
+.tabs-right > .nav-tabs .active > a,
+.tabs-right > .nav-tabs .active > a:hover,
+.tabs-right > .nav-tabs .active > a:focus {
+  z-index: 1;
+  border-color: #ddd #ddd #ddd transparent;
+}
+
+body:not(.bse-no-conflict) .panel h1,
+body:not(.bse-no-conflict) .panel h2,
+body:not(.bse-no-conflict) .panel h3,
+body:not(.bse-no-conflict) .panel h4,
+body:not(.bse-no-conflict) .panel h5 {
+  margin-top: 5px;
+}
+body:not(.bse-no-conflict) .panel .btn {
+  margin-bottom: 5px;
+}
+body:not(.bse-no-conflict) .panel .panel-heading .btn-group {
+  margin-top: -5px;
+}
+
+.list-group.b-0 > .list-group-item {
+  border-right: 0;
+  border-left: 0;
+}
+
+.list-group.b-0 > .list-group-item:first-child,
+.list-group.b-0 > .list-group-item:last-child {
+  border-radius: 0;
+}
+
+@media (min-width: 1200px) {
+  .row-split [class*='col-lg']:not(:last-child):not(.col-ld-12) {
+    border-right: 1px solid #ddd;
+  }
+}
+
+@media (min-width: 992px) {
+  .row-split [class*='col-md']:not(:last-child):not(.col-md-12) {
+    border-right: 1px solid #ddd;
+  }
+}
+
+@media (min-width: 768px) {
+  .row-split [class*='col-sm']:not(:last-child):not(.col-sm-12) {
+    border-right: 1px solid #ddd;
+  }
+}
+
+.row-split [class*='col-xs']:not(:last-child):not(.col-xs-12) {
+  border-right: 1px solid #ddd;
+}
+
+.b {
+  border: 1px solid #ddd;
+}
+.b-0 {
+  border: 0 !important;
+}
+.bt {
+  border-top: 1px solid #ddd;
+}
+.bt-0 {
+  border-top: 0 !important;
+}
+.br {
+  border-right: 1px solid #ddd;
+}
+.br-0 {
+  border-right: 0 !important;
+}
+.bb {
+  border-bottom: 1px solid #ddd;
+}
+.bb-0 {
+  border-bottom: 0 !important;
+}
+.bl {
+  border-left: 1px solid #ddd;
+}
+.bl-0 {
+  border-left: 0 !important;
+}
+
+.border {
+  border: 1px solid #ddd;
+}
+.border-0 {
+  border: 0 !important;
+}
+.border-top {
+  border-top: 1px solid #ddd;
+}
+.border-top-0 {
+  border-top: 0 !important;
+}
+.border-right {
+  border-right: 1px solid #ddd;
+}
+.border-right-0 {
+  border-right: 0 !important;
+}
+.border-bottom {
+  border-bottom: 1px solid #ddd;
+}
+.border-bottom-0 {
+  border-bottom: 0 !important;
+}
+.border-left {
+  border-left: 1px solid #ddd;
+}
+.border-left-0 {
+  border-left: 0 !important;
+}
+
+.rounded {
+  border-radius: 4px !important;
+}
+.rounded-top {
+  border-top-left-radius: 4px !important;
+  border-top-right-radius: 4px !important;
+}
+.rounded-right {
+  border-top-right-radius: 4px !important;
+  border-bottom-right-radius: 4px !important;
+}
+.rounded-bottom {
+  border-bottom-right-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
+}
+.rounded-left {
+  border-top-left-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
+}
+.rounded-circle {
+  border-radius: 50% !important;
+}
+.rounded-0 {
+  border-radius: 0 !important;
+}
+
+.row.gutter-0 {
+  margin-right: -0;
+  margin-left: -0;
+}
+@media (min-width: 768px) {
+  .row.gutter-0.gutter-justified {
+    margin-right: -15px;
+    margin-left: -15px;
+  }
+}
+.row.gutter-0 > [class^="col-"],
+.row.gutter-0 > [class^=" col-"] {
+  padding-right: 0;
+  padding-left: 0;
+}
+.row.gutter-5 {
+  margin-right: -2.5px;
+  margin-left: -2.5px;
+}
+@media (min-width: 768px) {
+  .row.gutter-5.gutter-justified {
+    margin-right: -12.5px;
+    margin-left: -12.5px;
+  }
+}
+.row.gutter-5 > [class^="col-"],
+.row.gutter-5 > [class^=" col-"] {
+  padding-right: 2.5px;
+  padding-left: 2.5px;
+}
+.row.gutter-10 {
+  margin-right: -5px;
+  margin-left: -5px;
+}
+@media (min-width: 768px) {
+  .row.gutter-10.gutter-justified {
+    margin-right: -10px;
+    margin-left: -10px;
+  }
+}
+.row.gutter-10 > [class^="col-"],
+.row.gutter-10 > [class^=" col-"] {
+  padding-right: 5px;
+  padding-left: 5px;
+}
+.row.gutter-15 {
+  margin-right: -7.5px;
+  margin-left: -7.5px;
+}
+@media (min-width: 768px) {
+  .row.gutter-15.gutter-justified {
+    margin-right: -7.5px;
+    margin-left: -7.5px;
+  }
+}
+.row.gutter-15 > [class^="col-"],
+.row.gutter-15 > [class^=" col-"] {
+  padding-right: 7.5px;
+  padding-left: 7.5px;
+}
+.row.gutter-20 {
+  margin-right: -10px;
+  margin-left: -10px;
+}
+@media (min-width: 768px) {
+  .row.gutter-20.gutter-justified {
+    margin-right: -5px;
+    margin-left: -5px;
+  }
+}
+.row.gutter-20 > [class^="col-"],
+.row.gutter-20 > [class^=" col-"] {
+  padding-right: 10px;
+  padding-left: 10px;
+}
+@media (min-width: 768px) {
+  .row.gutter-justified {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
+.list-inline.separated li {
+  padding: 0;
+}
+.list-inline.separated li + li:before {
+  content: "  |   ";
+}
+.list-inline.separated li + li * {
+  display: inline-block;
+}
+
+@media (max-width: 767px) {
+  .center-list-xs {
+    display: table;
+    padding-left: 0;
+    margin: 0 auto;
+  }
+}
+.avatar {
+  position: relative;
+  top: 1px;
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  text-align: center;
+  text-transform: uppercase;
+  vertical-align: middle;
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.avatar.img-thumbnail {
+  max-width: none;
+  padding: 4px;
+}
+
+.avatar,
+.avatar-32 {
+  width: 32px;
+  height: 100%;
+  max-height: 32px;
+  font-size: 20px;
+  line-height: 32px;
+}
+
+.avatar-16 {
+  width: 16px;
+  height: 100%;
+  max-height: 16px;
+  font-size: 10px;
+  line-height: 16px;
+}
+
+.avatar-24 {
+  width: 24px;
+  height: 100%;
+  max-height: 24px;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.avatar-48 {
+  width: 48px;
+  height: 100%;
+  max-height: 48px;
+  font-size: 32px;
+  line-height: 48px;
+}
+
+.avatar-64 {
+  width: 64px;
+  height: 100%;
+  max-height: 64px;
+  font-size: 40px;
+  line-height: 64px;
+}
+
+.avatar-96 {
+  width: 96px;
+  height: 100%;
+  max-height: 96px;
+  font-size: 64px;
+  line-height: 96px;
+}
+
+.avatar-128 {
+  width: 128px;
+  height: 100%;
+  max-height: 128px;
+  font-size: 80px;
+  line-height: 128px;
+}
+
+.progress.progress-xs {
+  height: 5px;
+  margin-bottom: 10px;
+}
+.progress.progress-sm {
+  height: 10px;
+  margin-bottom: 10px;
+}
+
+.navmenu {
+  width: 240px;
+  height: 100%;
+}
+.navmenu.navbar-default, .navmenu.navbar-inverse {
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 4px;
+}
+
+.navmenu-fixed-left,
+.navmenu-fixed-right {
+  position: fixed;
+  top: 0;
+  z-index: 1030;
+  overflow-y: auto;
+}
+
+.navmenu-fixed-left {
+  right: auto;
+  bottom: 0;
+  left: 0;
+}
+
+.navbar-default.navmenu-fixed-left,
+.navbar-inverse.navmenu-fixed-left {
+  border-width: 0 1px 0 0;
+  border-radius: 0;
+}
+
+.navmenu-fixed-right {
+  right: 0;
+  left: auto !important;
+}
+
+.navbar-default.navmenu-fixed-right,
+.navbar-inverse.navmenu-fixed-right {
+  border-width: 0 0 0 1px;
+  border-radius: 0;
+}
+
+.navmenu.navbar-inverse .dropdown-menu .divider {
+  background-color: #090909;
+}
+
+.navmenu .navbar-nav {
+  margin: 0;
+  margin-bottom: 10px;
+}
+.navmenu .navbar-nav .dropdown .caret {
+  float: right;
+  margin-top: .6em;
+  margin-right: .5em;
+}
+.navmenu .navbar-nav.dropdown-menu {
+  position: static;
+  float: none;
+  padding-top: 0;
+  margin: 0;
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+}
+.navmenu .navbar-nav.dropdown-menu > li > a,
+.navmenu .navbar-nav.dropdown-menu .dropdown-header {
+  padding: 5px 15px 5px 25px;
+}
+@media (min-width: 768px) {
+  .navmenu .navbar-nav {
+    float: none;
+    width: auto;
+  }
+}
+.navmenu .navbar-nav > li {
+  float: none !important;
+}
+.navmenu .navbar-nav > li > a {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.navmenu .navbar-brand {
+  display: block;
+  float: none;
+}
+
+.navbar + .navmenu {
+  z-index: 1029;
+  border-top: 1px solid transparent;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .1);
+          box-shadow: inset 0 1px 0 rgba(255, 255, 255, .1);
+}
+
+.navmenu-modal {
+  z-index: 1025 !important;
+}
+
+.offcanvas {
+  display: none;
+}
+.offcanvas.in {
+  display: block;
+}
+
+@media (max-width: 767px) {
+  .offcanvas-xs {
+    display: none;
+  }
+  .offcanvas-xs.in {
+    display: block;
+  }
+}
+@media (max-width: 991px) {
+  .offcanvas-sm {
+    display: none;
+  }
+  .offcanvas-sm.in {
+    display: block;
+  }
+}
+@media (max-width: 1199px) {
+  .offcanvas-md {
+    display: none;
+  }
+  .offcanvas-md.in {
+    display: block;
+  }
+}
+.offcanvas-lg {
+  display: none;
+}
+.offcanvas-lg.in {
+  display: block;
+}
+
+.canvas-sliding {
+  -webkit-transition: top .35s, left .35s, bottom .35s, right .35s;
+          transition: top .35s, left .35s, bottom .35s, right .35s;
+}
+
+.offcanvas-clone {
+  position: absolute !important;
+  top: auto !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: auto !important;
+  width: 0 !important;
+  height: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  border: none !important;
+  opacity: 0 !important;
+}
+
+.btn-file {
+  position: relative;
+  overflow: hidden;
+  vertical-align: middle;
+}
+.btn-file > input {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  font-size: 23px;
+  cursor: pointer;
+  filter: alpha(opacity=0);
+  opacity: 0;
+
+  direction: ltr;
+}
+
+.fileinput {
+  display: inline-block;
+  margin-bottom: 9px;
+}
+.fileinput .form-control {
+  display: inline-block;
+  padding-top: 7px;
+  padding-bottom: 5px;
+  margin-bottom: 0;
+  vertical-align: middle;
+  cursor: text;
+}
+.fileinput .thumbnail {
+  display: inline-block;
+  margin-bottom: 5px;
+  overflow: hidden;
+  text-align: center;
+  vertical-align: middle;
+}
+.fileinput .thumbnail > img {
+  max-height: 100%;
+}
+.fileinput .btn {
+  vertical-align: middle;
+}
+
+.fileinput-exists .fileinput-new,
+.fileinput-new .fileinput-exists {
+  display: none;
+}
+
+.fileinput-exists.close {
+  float: none;
+}
+
+.fileinput-inline .fileinput-controls {
+  display: inline;
+}
+
+.fileinput-filename {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.form-control .fileinput-filename {
+  vertical-align: bottom;
+}
+
+.fileinput.input-group {
+  display: table;
+}
+
+.fileinput-new.input-group .btn-file,
+.fileinput-new .input-group .btn-file {
+  border-radius: 0 4px 4px 0;
+}
+.fileinput-new.input-group .btn-file.btn-xs, .fileinput-new.input-group .btn-file.btn-sm,
+.fileinput-new .input-group .btn-file.btn-xs,
+.fileinput-new .input-group .btn-file.btn-sm {
+  border-radius: 0 3px 3px 0;
+}
+.fileinput-new.input-group .btn-file.btn-lg,
+.fileinput-new .input-group .btn-file.btn-lg {
+  border-radius: 0 6px 6px 0;
+}
+
+.form-group.has-warning .fileinput .fileinput-preview {
+  color: #8a6d3b;
+}
+.form-group.has-warning .fileinput .thumbnail {
+  border-color: #faebcc;
+}
+
+.form-group.has-error .fileinput .fileinput-preview {
+  color: #a94442;
+}
+.form-group.has-error .fileinput .thumbnail {
+  border-color: #ebccd1;
+}
+
+.form-group.has-success .fileinput .fileinput-preview {
+  color: #3c763d;
+}
+.form-group.has-success .fileinput .thumbnail {
+  border-color: #d6e9c6;
+}
+
+.input-group-addon:not(:first-child) {
+  border-left: 0;
+}
+
+.footer {
+  width: 100%;
+  padding-top: 30px;
+  border-top-style: solid;
+  border-top-width: 1px;
+}
+.footer.navbar-default, .footer.navbar-default a {
+  color: #777;
+}
+.footer.navbar-inverse, .footer.navbar-inverse a {
+  color: #9d9d9d;
+}
+.footer.bg-primary a {
+  color: inherit;
+}
+
+html.has-sticky-footer {
+  position: relative;
+  min-height: 100%;
+}
+html.has-sticky-footer .footer {
+  position: absolute;
+  bottom: 0;
+}
+
+.btn-circle {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
+  border-radius: 15px;
+}
+.btn-circle.btn-lg {
+  width: 50px;
+  height: 50px;
+  font-size: 20px;
+  line-height: 1.33;
+  border-radius: 25px;
+}
+.btn-circle .glyphicon {
+  left: 1px;
+  line-height: inherit;
+}
+
+a.btn-circle, a.btn-circle.btn-lg {
+  padding-top: 6px;
+}
+
+.btn-outline {
+  color: inherit;
+  background-color: transparent;
+  background-image: none;
+  -webkit-transition: all .5s;
+          transition: all .5s;
+}
+.btn-outline.btn-default {
+  color: #ccc;
+}
+.btn-outline.btn-primary {
+  color: #2e6da4;
+}
+.btn-outline.btn-success {
+  color: #4cae4c;
+}
+.btn-outline.btn-info {
+  color: #46b8da;
+}
+.btn-outline.btn-warning {
+  color: #eea236;
+}
+.btn-outline.btn-danger {
+  color: #d43f3a;
+}
+.btn-outline:hover.btn-primary, .btn-outline:hover.btn-success, .btn-outline:hover.btn-info, .btn-outline:hover.btn-warning, .btn-outline:hover.btn-danger {
+  color: #fff;
+}
+
+.btn-rounded {
+  border-radius: 50px;
+}
+
+@media (max-width: 767px) {
+  .btn-block-xs {
+    display: block;
+    width: 100%;
+  }
+  .btn-block-xs + .btn-block-xs {
+    margin-top: 5px;
+  }
+
+  .modal-footer .btn-block-xs + .btn-block-xs {
+    margin-left: 0;
+  }
+}
+.action-btn {
+  position: fixed !important;
+  right: 15px;
+  bottom: 15px;
+  left: auto !important;
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: visibility 0s linear 0s, opacity .35s !important;
+          transition: visibility 0s linear 0s, opacity .35s !important;
+}
+.action-btn.affix-top {
+  visibility: hidden;
+  opacity: 0;
+  -webkit-transition: visibility 0s linear .35s, opacity .35s !important;
+          transition: visibility 0s linear .35s, opacity .35s !important;
+}
+.action-btn.action-btn-left {
+  right: auto !important;
+  left: 15px;
+}
+
+.text-xs-left {
+  text-align: left !important;
+}
+
+.text-xs-right {
+  text-align: right !important;
+}
+
+.text-xs-center {
+  text-align: center !important;
+}
+
+@media (min-width: 768px) {
+  .text-sm-left {
+    text-align: left !important;
+  }
+
+  .text-sm-right {
+    text-align: right !important;
+  }
+
+  .text-sm-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 992px) {
+  .text-md-left {
+    text-align: left !important;
+  }
+
+  .text-md-right {
+    text-align: right !important;
+  }
+
+  .text-md-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 1200px) {
+  .text-lg-left {
+    text-align: left !important;
+  }
+
+  .text-lg-right {
+    text-align: right !important;
+  }
+
+  .text-lg-center {
+    text-align: center !important;
+  }
+}
+.fs-xs-0-5 {
+  font-size: .5em;
+}
+
+.fs-xs-0-6 {
+  font-size: .6em;
+}
+
+.fs-xs-0-7 {
+  font-size: .7em;
+}
+
+.fs-xs-0-8 {
+  font-size: .8em;
+}
+
+.fs-xs-0-9 {
+  font-size: .9em;
+}
+
+.fs-xs-1-0 {
+  font-size: 1.0em;
+}
+
+.fs-xs-1-1 {
+  font-size: 1.1em;
+}
+
+.fs-xs-1-2 {
+  font-size: 1.2em;
+}
+
+.fs-xs-1-3 {
+  font-size: 1.3em;
+}
+
+.fs-xs-1-4 {
+  font-size: 1.4em;
+}
+
+.fs-xs-1-5 {
+  font-size: 1.5em;
+}
+
+.fs-xs-1-6 {
+  font-size: 1.6em;
+}
+
+.fs-xs-1-7 {
+  font-size: 1.7em;
+}
+
+.fs-xs-1-8 {
+  font-size: 1.8em;
+}
+
+.fs-xs-1-9 {
+  font-size: 1.9em;
+}
+
+.fs-xs-2-0 {
+  font-size: 2.0em;
+}
+
+.fs-xs-2-2 {
+  font-size: 2.2em;
+}
+
+.fs-xs-2-4 {
+  font-size: 2.4em;
+}
+
+.fs-xs-2-5 {
+  font-size: 2.5em;
+}
+
+.fs-xs-2-6 {
+  font-size: 2.6em;
+}
+
+.fs-xs-2-8 {
+  font-size: 2.8em;
+}
+
+.fs-xs-3-0 {
+  font-size: 3.0em;
+}
+
+.fs-xs-3-2 {
+  font-size: 3.2em;
+}
+
+.fs-xs-4-0 {
+  font-size: 4.0em;
+}
+
+@media (min-width: 768px) {
+  .fs-sm-0-5 {
+    font-size: .5em;
+  }
+
+  .fs-sm-0-6 {
+    font-size: .6em;
+  }
+
+  .fs-sm-0-7 {
+    font-size: .7em;
+  }
+
+  .fs-sm-0-8 {
+    font-size: .8em;
+  }
+
+  .fs-sm-0-9 {
+    font-size: .9em;
+  }
+
+  .fs-sm-1-0 {
+    font-size: 1.0em;
+  }
+
+  .fs-sm-1-1 {
+    font-size: 1.1em;
+  }
+
+  .fs-sm-1-2 {
+    font-size: 1.2em;
+  }
+
+  .fs-sm-1-3 {
+    font-size: 1.3em;
+  }
+
+  .fs-sm-1-4 {
+    font-size: 1.4em;
+  }
+
+  .fs-sm-1-5 {
+    font-size: 1.5em;
+  }
+
+  .fs-sm-1-6 {
+    font-size: 1.6em;
+  }
+
+  .fs-sm-1-7 {
+    font-size: 1.7em;
+  }
+
+  .fs-sm-1-8 {
+    font-size: 1.8em;
+  }
+
+  .fs-sm-1-9 {
+    font-size: 1.9em;
+  }
+
+  .fs-sm-2-0 {
+    font-size: 2.0em;
+  }
+
+  .fs-sm-2-2 {
+    font-size: 2.2em;
+  }
+
+  .fs-sm-2-4 {
+    font-size: 2.4em;
+  }
+
+  .fs-sm-2-5 {
+    font-size: 2.5em;
+  }
+
+  .fs-sm-2-6 {
+    font-size: 2.6em;
+  }
+
+  .fs-sm-2-8 {
+    font-size: 2.8em;
+  }
+
+  .fs-sm-3-0 {
+    font-size: 3.0em;
+  }
+
+  .fs-sm-3-2 {
+    font-size: 3.2em;
+  }
+
+  .fs-sm-4-0 {
+    font-size: 4.0em;
+  }
+}
+@media (min-width: 992px) {
+  .fs-md-0-5 {
+    font-size: .5em;
+  }
+
+  .fs-md-0-6 {
+    font-size: .6em;
+  }
+
+  .fs-md-0-7 {
+    font-size: .7em;
+  }
+
+  .fs-md-0-8 {
+    font-size: .8em;
+  }
+
+  .fs-md-0-9 {
+    font-size: .9em;
+  }
+
+  .fs-md-1-0 {
+    font-size: 1.0em;
+  }
+
+  .fs-md-1-1 {
+    font-size: 1.1em;
+  }
+
+  .fs-md-1-2 {
+    font-size: 1.2em;
+  }
+
+  .fs-md-1-3 {
+    font-size: 1.3em;
+  }
+
+  .fs-md-1-4 {
+    font-size: 1.4em;
+  }
+
+  .fs-md-1-5 {
+    font-size: 1.5em;
+  }
+
+  .fs-md-1-6 {
+    font-size: 1.6em;
+  }
+
+  .fs-md-1-7 {
+    font-size: 1.7em;
+  }
+
+  .fs-md-1-8 {
+    font-size: 1.8em;
+  }
+
+  .fs-md-1-9 {
+    font-size: 1.9em;
+  }
+
+  .fs-md-2-0 {
+    font-size: 2.0em;
+  }
+
+  .fs-md-2-2 {
+    font-size: 2.2em;
+  }
+
+  .fs-md-2-4 {
+    font-size: 2.4em;
+  }
+
+  .fs-md-2-5 {
+    font-size: 2.5em;
+  }
+
+  .fs-md-2-6 {
+    font-size: 2.6em;
+  }
+
+  .fs-md-2-8 {
+    font-size: 2.8em;
+  }
+
+  .fs-md-3-0 {
+    font-size: 3.0em;
+  }
+
+  .fs-md-3-2 {
+    font-size: 3.2em;
+  }
+
+  .fs-md-4-0 {
+    font-size: 4.0em;
+  }
+}
+@media (min-width: 1200px) {
+  .fs-lg-0-5 {
+    font-size: .5em;
+  }
+
+  .fs-lg-0-6 {
+    font-size: .6em;
+  }
+
+  .fs-lg-0-7 {
+    font-size: .7em;
+  }
+
+  .fs-lg-0-8 {
+    font-size: .8em;
+  }
+
+  .fs-lg-0-9 {
+    font-size: .9em;
+  }
+
+  .fs-lg-1-0 {
+    font-size: 1.0em;
+  }
+
+  .fs-lg-1-1 {
+    font-size: 1.1em;
+  }
+
+  .fs-lg-1-2 {
+    font-size: 1.2em;
+  }
+
+  .fs-lg-1-3 {
+    font-size: 1.3em;
+  }
+
+  .fs-lg-1-4 {
+    font-size: 1.4em;
+  }
+
+  .fs-lg-1-5 {
+    font-size: 1.5em;
+  }
+
+  .fs-lg-1-6 {
+    font-size: 1.6em;
+  }
+
+  .fs-lg-1-7 {
+    font-size: 1.7em;
+  }
+
+  .fs-lg-1-8 {
+    font-size: 1.8em;
+  }
+
+  .fs-lg-1-9 {
+    font-size: 1.9em;
+  }
+
+  .fs-lg-2-0 {
+    font-size: 2.0em;
+  }
+
+  .fs-lg-2-2 {
+    font-size: 2.2em;
+  }
+
+  .fs-lg-2-4 {
+    font-size: 2.4em;
+  }
+
+  .fs-lg-2-5 {
+    font-size: 2.5em;
+  }
+
+  .fs-lg-2-6 {
+    font-size: 2.6em;
+  }
+
+  .fs-lg-2-8 {
+    font-size: 2.8em;
+  }
+
+  .fs-lg-3-0 {
+    font-size: 3.0em;
+  }
+
+  .fs-lg-3-2 {
+    font-size: 3.2em;
+  }
+
+  .fs-lg-4-0 {
+    font-size: 4.0em;
+  }
+}
+.font-weight-normal {
+  font-weight: normal;
+}
+
+.font-weight-bold {
+  font-weight: bold;
+}
+
+.font-italic {
+  font-style: italic;
+}
+
+.no-underline, .no-underline:hover, .no-underline:visited {
+  text-decoration: none !important;
+}
+
+.text-body {
+  color: #333;
+}
+
+.container-xs {
+  max-width: 480px;
+}
+
+.container-sm {
+  max-width: 750px;
+}
+
+.container-md {
+  max-width: 970px;
+}
+
+.container-smooth {
+  max-width: 1170px;
+}
+.container-smooth.container-md {
+  max-width: 970px;
+}
+@media (min-width: 1px) {
+  .container-smooth {
+    width: auto;
+  }
+}
+
+/* 
+	Flex Container, Row and Column for equal height
+	Panels/Wells/Thumbnails 
+*/
+.container-flex > .row,
+.container-flex > .row > div[class*='col-'],
+.row-flex,
+.row-flex > div[class*='col-'] {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display:         flex;
+
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
+}
+
+.row-flex-wrap,
+.container-flex > .row {
+  -webkit-flex-flow: row wrap;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
+  -webkit-align-content: flex-start;
+  -ms-flex-line-pack: start;
+          align-content: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0;
+      -ms-flex: 0;
+          flex: 0;
+}
+
+.container-flex > .row > div[class*='col-'],
+.row-flex > div[class*='col-'],
+.container-flex > div[class*='col-'] {
+  margin: -.2px;
+  /* hack adjust for wrapping */
+}
+
+.container-flex > .row > div[class*='col-'] > div,
+.container-flex > div[class*='col-'] div,
+.row-flex > div[class*='col-'] div {
+  width: 100%;
+}
+
+.flex-col {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display:         flex;
+  display: -webkit-flex;
+
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 100%;
+      -ms-flex: 1 100%;
+          flex: 1 100%;
+  -webkit-flex-flow: column nowrap;
+      -ms-flex-flow: column nowrap;
+          flex-flow: column nowrap;
+}
+
+.flex-grow {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display:         flex;
+
+  -webkit-flex: 2;
+  -webkit-box-flex: 2;
+      -ms-flex: 2;
+          flex: 2;
+}
+
+.container-table {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+}
+.container-table > .row {
+  display: table-row;
+}
+.container-table > .row > [class*=col-] {
+  display: block;
+}
+@media (min-width: 1200px) {
+  .container-table > .row > [class*=col-lg]:not(.col-lg-12) {
+    display: table-cell;
+    float: none;
+  }
+}
+@media (min-width: 992px) {
+  .container-table > .row > [class*=col-md]:not(.col-md-12) {
+    display: table-cell;
+    float: none;
+  }
+}
+@media (min-width: 768px) {
+  .container-table > .row > [class*=col-sm]:not(.col-sm-12) {
+    display: table-cell;
+    float: none;
+  }
+}
+.container-table > .row > [class^=col-xs-]:not(.col-xs-12) {
+  display: table-cell;
+  float: none;
+}
+
+.container-login {
+  max-width: 330px;
+  padding-top: 100px;
+}
+
+.container-login-2 {
+  max-width: 830px;
+  padding-top: 100px;
+}
+
+.container-login,
+.container-login-2 {
+  z-index: 100;
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+body:not(.bse-no-conflict) .navbar-toggle.pull-left {
+  float: left;
+  margin-left: 15px;
+}
+@media (max-width: 767px) {
+  body:not(.bse-no-conflict) .navbar-toggle.pull-left {
+    margin-right: 0;
+  }
+}
+body:not(.bse-no-conflict) [class*="container"] > .navbar-toggle.pull-left {
+  margin-left: 0;
+}
+
+@media (max-width: 767px) {
+  .navbar-slide-nav {
+    border-top: 0;
+  }
+  .navbar-slide-nav .navbar-nav {
+    margin-right: 0;
+    margin-left: 0;
+  }
+  .navbar-slide-nav [class*="container"] {
+    background-color: inherit;
+    border-color: inherit;
+  }
+  .navbar-slide-nav .navbar-slide {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1030;
+    width: 240px;
+    height: 100%;
+    margin: 0;
+    overflow: auto;
+    background-color: inherit;
+    border-right: 1px solid;
+    border-right-color: inherit;
+  }
+  .navbar-slide-nav .navbar-slide .navbar-nav .dropdown-menu li a {
+    width: 100%;
+    white-space: normal;
+  }
+  .navbar-slide-nav .navbar-form {
+    width: 100%;
+    margin: 8px 0;
+    overflow: hidden;
+    text-align: center;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-slide {
+    display: block;
+    width: auto !important;
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+}
+/* 
+	CSS to Enable Navigation sub-menu of dropdown
+ */
+@media (max-width: 767px) {
+  .navbar-inverse .dropdown-submenu > a {
+    border-color: #090909;
+  }
+}
+
+.dropdown-submenu {
+  position: relative;
+}
+.dropdown-submenu > .dropdown-menu {
+  top: 0;
+  left: 100%;
+  margin-top: -6px;
+  margin-left: -1px;
+  border-radius: 0 4px 4px 4px;
+}
+@media (max-width: 767px) {
+  .dropdown-submenu > .dropdown-menu {
+    display: block;
+  }
+}
+.dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+@media (max-width: 767px) {
+  .dropdown-submenu > a {
+    padding: 3px 20px !important;
+    padding-top: 14px !important;
+    margin-top: 9px;
+    font-size: 12px;
+    line-height: 1.428571429 !important;
+    color: #777 !important;
+    border-top: 1px solid #e5e5e5;
+  }
+}
+.dropdown-submenu > a > .caret {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  display: inline-block;
+  margin-top: -2px;
+  -webkit-transform: rotate(270deg);
+          transform: rotate(270deg);
+}
+@media (max-width: 767px) {
+  .dropdown-submenu > a > .caret {
+    display: none !important;
+  }
+}
+
+.navbar-fixed-bottom .dropdown-submenu > .dropdown-menu {
+  bottom: 0;
+  border-radius: 4px 4px 4px 0;
+}
+.navbar-fixed-bottom .dropdown-submenu > a > .caret {
+  -webkit-transform: rotate(90deg);
+          transform: rotate(90deg);
+}
+
+.navbar-right .dropdown-submenu > .dropdown-menu {
+  right: 100%;
+  left: auto;
+  margin-left: 10px;
+  border-radius: 4px 0 4px 4px;
+}
+
+.navbar-right-static {
+  float: right !important;
+}
+.navbar-right-static .navbar-nav {
+  margin: 0;
+}
+.navbar-right-static .navbar-nav > li {
+  float: left;
+}
+.navbar-right-static .navbar-nav > li > a {
+  padding-top: 0;
+  padding-bottom: 0;
+  line-height: 50px;
+}
+.navbar-right-static .dropdown-menu {
+  right: 0;
+  left: auto;
+}
+
+[class*="container"] > .navbar-right-static {
+  margin-right: -15px;
+}
+
+@media (min-width: 768px) {
+  .navbar-justified {
+    padding-right: 0;
+    padding-left: 0;
+  }
+  .navbar-justified .navbar-nav {
+    display: table;
+    float: none;
+    width: 100% !important;
+    margin: 0 auto;
+    table-layout: auto;
+  }
+  .navbar-justified .navbar-nav > li {
+    display: table-cell;
+    float: none;
+    text-align: center;
+  }
+}
+.pt-navbar-height {
+  padding-top: 50px;
+}
+
+.pb-navbar-height {
+  padding-bottom: 50px;
+}
+
+.mt-navbar-height {
+  margin-top: 50px;
+}
+.mt-navbar-height.navmenu {
+  height: -webkit-calc(100% - 50px);
+  height:         calc(100% - 50px);
+}
+
+.mb-navbar-height {
+  margin-bottom: 50px;
+}
+
+@media (max-width: 767px) {
+  .break-xs {
+    width: 100% !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .break-sm {
+    width: 100% !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .break-md {
+    width: 100% !important;
+  }
+}
+@media (min-width: 1200px) {
+  .break-lg {
+    width: 100% !important;
+  }
+}
+.bg-white {
+  background-color: #fff !important;
+}
+
+.bg-transparent {
+  background-color: transparent !important;
+}
+
+.bg-well {
+  background-color: #f5f5f5 !important;
+}
+
+.bg-jumbotron {
+  background-color: #eee !important;
+}
+
+.bg-img {
+  background-color: #414141;
+  background-repeat: no-repeat;
+  background-position: center center;
+  -webkit-background-size: cover;
+          background-size: cover;
+}
+
+.text-white {
+  color: #fff !important;
+}
+
+.vertical-middle > * {
+  vertical-align: middle;
+}
+.vertical-top > * {
+  vertical-align: top;
+}
+.vertical-bottom > * {
+  vertical-align: bottom;
+}
+
+.fill {
+  width: 100%;
+  height: 100%;
+}
+
+.full-height {
+  height: 100%;
+}
+
+.p-0 {
+  padding: 0 !important;
+}
+
+.p-xs-0 {
+  padding: 0 !important;
+}
+
+.p-1 {
+  padding: 5px !important;
+}
+
+.p-xs-1 {
+  padding: 5px !important;
+}
+
+.p-2 {
+  padding: 10px !important;
+}
+
+.p-xs-2 {
+  padding: 10px !important;
+}
+
+.p-3 {
+  padding: 15px !important;
+}
+
+.p-xs-3 {
+  padding: 15px !important;
+}
+
+.p-4 {
+  padding: 25px !important;
+}
+
+.p-xs-4 {
+  padding: 25px !important;
+}
+
+.p-5 {
+  padding: 50px !important;
+}
+
+.p-xs-5 {
+  padding: 50px !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pt-xs-0 {
+  padding-top: 0 !important;
+}
+
+.pt-1 {
+  padding-top: 5px !important;
+}
+
+.pt-xs-1 {
+  padding-top: 5px !important;
+}
+
+.pt-2 {
+  padding-top: 10px !important;
+}
+
+.pt-xs-2 {
+  padding-top: 10px !important;
+}
+
+.pt-3 {
+  padding-top: 15px !important;
+}
+
+.pt-xs-3 {
+  padding-top: 15px !important;
+}
+
+.pt-4 {
+  padding-top: 25px !important;
+}
+
+.pt-xs-4 {
+  padding-top: 25px !important;
+}
+
+.pt-5 {
+  padding-top: 50px !important;
+}
+
+.pt-xs-5 {
+  padding-top: 50px !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pr-xs-0 {
+  padding-right: 0 !important;
+}
+
+.pr-1 {
+  padding-right: 5px !important;
+}
+
+.pr-xs-1 {
+  padding-right: 5px !important;
+}
+
+.pr-2 {
+  padding-right: 10px !important;
+}
+
+.pr-xs-2 {
+  padding-right: 10px !important;
+}
+
+.pr-3 {
+  padding-right: 15px !important;
+}
+
+.pr-xs-3 {
+  padding-right: 15px !important;
+}
+
+.pr-4 {
+  padding-right: 25px !important;
+}
+
+.pr-xs-4 {
+  padding-right: 25px !important;
+}
+
+.pr-5 {
+  padding-right: 50px !important;
+}
+
+.pr-xs-5 {
+  padding-right: 50px !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.pb-xs-0 {
+  padding-bottom: 0 !important;
+}
+
+.pb-1 {
+  padding-bottom: 5px !important;
+}
+
+.pb-xs-1 {
+  padding-bottom: 5px !important;
+}
+
+.pb-2 {
+  padding-bottom: 10px !important;
+}
+
+.pb-xs-2 {
+  padding-bottom: 10px !important;
+}
+
+.pb-3 {
+  padding-bottom: 15px !important;
+}
+
+.pb-xs-3 {
+  padding-bottom: 15px !important;
+}
+
+.pb-4 {
+  padding-bottom: 25px !important;
+}
+
+.pb-xs-4 {
+  padding-bottom: 25px !important;
+}
+
+.pb-5 {
+  padding-bottom: 50px !important;
+}
+
+.pb-xs-5 {
+  padding-bottom: 50px !important;
+}
+
+.pl-0 {
+  padding-left: 0 !important;
+}
+
+.pl-xs-0 {
+  padding-left: 0 !important;
+}
+
+.pl-1 {
+  padding-left: 5px !important;
+}
+
+.pl-xs-1 {
+  padding-left: 5px !important;
+}
+
+.pl-2 {
+  padding-left: 10px !important;
+}
+
+.pl-xs-2 {
+  padding-left: 10px !important;
+}
+
+.pl-3 {
+  padding-left: 15px !important;
+}
+
+.pl-xs-3 {
+  padding-left: 15px !important;
+}
+
+.pl-4 {
+  padding-left: 25px !important;
+}
+
+.pl-xs-4 {
+  padding-left: 25px !important;
+}
+
+.pl-5 {
+  padding-left: 50px !important;
+}
+
+.pl-xs-5 {
+  padding-left: 50px !important;
+}
+
+.m-0 {
+  margin: 0 !important;
+}
+
+.m-xs-0 {
+  margin: 0 !important;
+}
+
+.m-1 {
+  margin: 5px !important;
+}
+
+.m-xs-1 {
+  margin: 5px !important;
+}
+
+.m-2 {
+  margin: 10px !important;
+}
+
+.m-xs-2 {
+  margin: 10px !important;
+}
+
+.m-3 {
+  margin: 15px !important;
+}
+
+.m-xs-3 {
+  margin: 15px !important;
+}
+
+.m-4 {
+  margin: 25px !important;
+}
+
+.m-xs-4 {
+  margin: 25px !important;
+}
+
+.m-5 {
+  margin: 50px !important;
+}
+
+.m-xs-5 {
+  margin: 50px !important;
+}
+
+.mt-0 {
+  margin-top: 0 !important;
+}
+
+.mt-xs-0 {
+  margin-top: 0 !important;
+}
+
+.mt-1 {
+  margin-top: 5px !important;
+}
+
+.mt-xs-1 {
+  margin-top: 5px !important;
+}
+
+.mt-2 {
+  margin-top: 10px !important;
+}
+
+.mt-xs-2 {
+  margin-top: 10px !important;
+}
+
+.mt-3 {
+  margin-top: 15px !important;
+}
+
+.mt-xs-3 {
+  margin-top: 15px !important;
+}
+
+.mt-4 {
+  margin-top: 25px !important;
+}
+
+.mt-xs-4 {
+  margin-top: 25px !important;
+}
+
+.mt-5 {
+  margin-top: 50px !important;
+}
+
+.mt-xs-5 {
+  margin-top: 50px !important;
+}
+
+.mr-0 {
+  margin-right: 0 !important;
+}
+
+.mr-xs-0 {
+  margin-right: 0 !important;
+}
+
+.mr-1 {
+  margin-right: 5px !important;
+}
+
+.mr-xs-1 {
+  margin-right: 5px !important;
+}
+
+.mr-2 {
+  margin-right: 10px !important;
+}
+
+.mr-xs-2 {
+  margin-right: 10px !important;
+}
+
+.mr-3 {
+  margin-right: 15px !important;
+}
+
+.mr-xs-3 {
+  margin-right: 15px !important;
+}
+
+.mr-4 {
+  margin-right: 25px !important;
+}
+
+.mr-xs-4 {
+  margin-right: 25px !important;
+}
+
+.mr-5 {
+  margin-right: 50px !important;
+}
+
+.mr-xs-5 {
+  margin-right: 50px !important;
+}
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-xs-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-1 {
+  margin-bottom: 5px !important;
+}
+
+.mb-xs-1 {
+  margin-bottom: 5px !important;
+}
+
+.mb-2 {
+  margin-bottom: 10px !important;
+}
+
+.mb-xs-2 {
+  margin-bottom: 10px !important;
+}
+
+.mb-3 {
+  margin-bottom: 15px !important;
+}
+
+.mb-xs-3 {
+  margin-bottom: 15px !important;
+}
+
+.mb-4 {
+  margin-bottom: 25px !important;
+}
+
+.mb-xs-4 {
+  margin-bottom: 25px !important;
+}
+
+.mb-5 {
+  margin-bottom: 50px !important;
+}
+
+.mb-xs-5 {
+  margin-bottom: 50px !important;
+}
+
+.ml-0 {
+  margin-left: 0 !important;
+}
+
+.ml-xs-0 {
+  margin-left: 0 !important;
+}
+
+.ml-1 {
+  margin-left: 5px !important;
+}
+
+.ml-xs-1 {
+  margin-left: 5px !important;
+}
+
+.ml-2 {
+  margin-left: 10px !important;
+}
+
+.ml-xs-2 {
+  margin-left: 10px !important;
+}
+
+.ml-3 {
+  margin-left: 15px !important;
+}
+
+.ml-xs-3 {
+  margin-left: 15px !important;
+}
+
+.ml-4 {
+  margin-left: 25px !important;
+}
+
+.ml-xs-4 {
+  margin-left: 25px !important;
+}
+
+.ml-5 {
+  margin-left: 50px !important;
+}
+
+.ml-xs-5 {
+  margin-left: 50px !important;
+}
+
+@media (min-width: 768px) {
+  .p-sm-0 {
+    padding: 0 !important;
+  }
+
+  .p-sm-1 {
+    padding: 5px !important;
+  }
+
+  .p-sm-2 {
+    padding: 10px !important;
+  }
+
+  .p-sm-3 {
+    padding: 15px !important;
+  }
+
+  .p-sm-4 {
+    padding: 25px !important;
+  }
+
+  .p-sm-5 {
+    padding: 50px !important;
+  }
+
+  .pt-sm-0 {
+    padding-top: 0 !important;
+  }
+
+  .pt-sm-1 {
+    padding-top: 5px !important;
+  }
+
+  .pt-sm-2 {
+    padding-top: 10px !important;
+  }
+
+  .pt-sm-3 {
+    padding-top: 15px !important;
+  }
+
+  .pt-sm-4 {
+    padding-top: 25px !important;
+  }
+
+  .pt-sm-5 {
+    padding-top: 50px !important;
+  }
+
+  .pr-sm-0 {
+    padding-right: 0 !important;
+  }
+
+  .pr-sm-1 {
+    padding-right: 5px !important;
+  }
+
+  .pr-sm-2 {
+    padding-right: 10px !important;
+  }
+
+  .pr-sm-3 {
+    padding-right: 15px !important;
+  }
+
+  .pr-sm-4 {
+    padding-right: 25px !important;
+  }
+
+  .pr-sm-5 {
+    padding-right: 50px !important;
+  }
+
+  .pb-sm-0 {
+    padding-bottom: 0 !important;
+  }
+
+  .pb-sm-1 {
+    padding-bottom: 5px !important;
+  }
+
+  .pb-sm-2 {
+    padding-bottom: 10px !important;
+  }
+
+  .pb-sm-3 {
+    padding-bottom: 15px !important;
+  }
+
+  .pb-sm-4 {
+    padding-bottom: 25px !important;
+  }
+
+  .pb-sm-5 {
+    padding-bottom: 50px !important;
+  }
+
+  .pl-sm-0 {
+    padding-left: 0 !important;
+  }
+
+  .pl-sm-1 {
+    padding-left: 5px !important;
+  }
+
+  .pl-sm-2 {
+    padding-left: 10px !important;
+  }
+
+  .pl-sm-3 {
+    padding-left: 15px !important;
+  }
+
+  .pl-sm-4 {
+    padding-left: 25px !important;
+  }
+
+  .pl-sm-5 {
+    padding-left: 50px !important;
+  }
+
+  .m-sm-0 {
+    margin: 0 !important;
+  }
+
+  .m-sm-1 {
+    margin: 5px !important;
+  }
+
+  .m-sm-2 {
+    margin: 10px !important;
+  }
+
+  .m-sm-3 {
+    margin: 15px !important;
+  }
+
+  .m-sm-4 {
+    margin: 25px !important;
+  }
+
+  .m-sm-5 {
+    margin: 50px !important;
+  }
+
+  .mt-sm-0 {
+    margin-top: 0 !important;
+  }
+
+  .mt-sm-1 {
+    margin-top: 5px !important;
+  }
+
+  .mt-sm-2 {
+    margin-top: 10px !important;
+  }
+
+  .mt-sm-3 {
+    margin-top: 15px !important;
+  }
+
+  .mt-sm-4 {
+    margin-top: 25px !important;
+  }
+
+  .mt-sm-5 {
+    margin-top: 50px !important;
+  }
+
+  .mr-sm-0 {
+    margin-right: 0 !important;
+  }
+
+  .mr-sm-1 {
+    margin-right: 5px !important;
+  }
+
+  .mr-sm-2 {
+    margin-right: 10px !important;
+  }
+
+  .mr-sm-3 {
+    margin-right: 15px !important;
+  }
+
+  .mr-sm-4 {
+    margin-right: 25px !important;
+  }
+
+  .mr-sm-5 {
+    margin-right: 50px !important;
+  }
+
+  .mb-sm-0 {
+    margin-bottom: 0 !important;
+  }
+
+  .mb-sm-1 {
+    margin-bottom: 5px !important;
+  }
+
+  .mb-sm-2 {
+    margin-bottom: 10px !important;
+  }
+
+  .mb-sm-3 {
+    margin-bottom: 15px !important;
+  }
+
+  .mb-sm-4 {
+    margin-bottom: 25px !important;
+  }
+
+  .mb-sm-5 {
+    margin-bottom: 50px !important;
+  }
+
+  .ml-sm-0 {
+    margin-left: 0 !important;
+  }
+
+  .ml-sm-1 {
+    margin-left: 5px !important;
+  }
+
+  .ml-sm-2 {
+    margin-left: 10px !important;
+  }
+
+  .ml-sm-3 {
+    margin-left: 15px !important;
+  }
+
+  .ml-sm-4 {
+    margin-left: 25px !important;
+  }
+
+  .ml-sm-5 {
+    margin-left: 50px !important;
+  }
+}
+@media (min-width: 992px) {
+  .p-md-0 {
+    padding: 0 !important;
+  }
+
+  .p-md-1 {
+    padding: 5px !important;
+  }
+
+  .p-md-2 {
+    padding: 10px !important;
+  }
+
+  .p-md-3 {
+    padding: 15px !important;
+  }
+
+  .p-md-4 {
+    padding: 25px !important;
+  }
+
+  .p-md-5 {
+    padding: 50px !important;
+  }
+
+  .pt-md-0 {
+    padding-top: 0 !important;
+  }
+
+  .pt-md-1 {
+    padding-top: 5px !important;
+  }
+
+  .pt-md-2 {
+    padding-top: 10px !important;
+  }
+
+  .pt-md-3 {
+    padding-top: 15px !important;
+  }
+
+  .pt-md-4 {
+    padding-top: 25px !important;
+  }
+
+  .pt-md-5 {
+    padding-top: 50px !important;
+  }
+
+  .pr-md-0 {
+    padding-right: 0 !important;
+  }
+
+  .pr-md-1 {
+    padding-right: 5px !important;
+  }
+
+  .pr-md-2 {
+    padding-right: 10px !important;
+  }
+
+  .pr-md-3 {
+    padding-right: 15px !important;
+  }
+
+  .pr-md-4 {
+    padding-right: 25px !important;
+  }
+
+  .pr-md-5 {
+    padding-right: 50px !important;
+  }
+
+  .pb-md-0 {
+    padding-bottom: 0 !important;
+  }
+
+  .pb-md-1 {
+    padding-bottom: 5px !important;
+  }
+
+  .pb-md-2 {
+    padding-bottom: 10px !important;
+  }
+
+  .pb-md-3 {
+    padding-bottom: 15px !important;
+  }
+
+  .pb-md-4 {
+    padding-bottom: 25px !important;
+  }
+
+  .pb-md-5 {
+    padding-bottom: 50px !important;
+  }
+
+  .pl-md-0 {
+    padding-left: 0 !important;
+  }
+
+  .pl-md-1 {
+    padding-left: 5px !important;
+  }
+
+  .pl-md-2 {
+    padding-left: 10px !important;
+  }
+
+  .pl-md-3 {
+    padding-left: 15px !important;
+  }
+
+  .pl-md-4 {
+    padding-left: 25px !important;
+  }
+
+  .pl-md-5 {
+    padding-left: 50px !important;
+  }
+
+  .m-md-0 {
+    margin: 0 !important;
+  }
+
+  .m-md-1 {
+    margin: 5px !important;
+  }
+
+  .m-md-2 {
+    margin: 10px !important;
+  }
+
+  .m-md-3 {
+    margin: 15px !important;
+  }
+
+  .m-md-4 {
+    margin: 25px !important;
+  }
+
+  .m-md-5 {
+    margin: 50px !important;
+  }
+
+  .mt-md-0 {
+    margin-top: 0 !important;
+  }
+
+  .mt-md-1 {
+    margin-top: 5px !important;
+  }
+
+  .mt-md-2 {
+    margin-top: 10px !important;
+  }
+
+  .mt-md-3 {
+    margin-top: 15px !important;
+  }
+
+  .mt-md-4 {
+    margin-top: 25px !important;
+  }
+
+  .mt-md-5 {
+    margin-top: 50px !important;
+  }
+
+  .mr-md-0 {
+    margin-right: 0 !important;
+  }
+
+  .mr-md-1 {
+    margin-right: 5px !important;
+  }
+
+  .mr-md-2 {
+    margin-right: 10px !important;
+  }
+
+  .mr-md-3 {
+    margin-right: 15px !important;
+  }
+
+  .mr-md-4 {
+    margin-right: 25px !important;
+  }
+
+  .mr-md-5 {
+    margin-right: 50px !important;
+  }
+
+  .mb-md-0 {
+    margin-bottom: 0 !important;
+  }
+
+  .mb-md-1 {
+    margin-bottom: 5px !important;
+  }
+
+  .mb-md-2 {
+    margin-bottom: 10px !important;
+  }
+
+  .mb-md-3 {
+    margin-bottom: 15px !important;
+  }
+
+  .mb-md-4 {
+    margin-bottom: 25px !important;
+  }
+
+  .mb-md-5 {
+    margin-bottom: 50px !important;
+  }
+
+  .ml-md-0 {
+    margin-left: 0 !important;
+  }
+
+  .ml-md-1 {
+    margin-left: 5px !important;
+  }
+
+  .ml-md-2 {
+    margin-left: 10px !important;
+  }
+
+  .ml-md-3 {
+    margin-left: 15px !important;
+  }
+
+  .ml-md-4 {
+    margin-left: 25px !important;
+  }
+
+  .ml-md-5 {
+    margin-left: 50px !important;
+  }
+}
+@media (min-width: 1200px) {
+  .p-lg-0 {
+    padding: 0 !important;
+  }
+
+  .p-lg-1 {
+    padding: 5px !important;
+  }
+
+  .p-lg-2 {
+    padding: 10px !important;
+  }
+
+  .p-lg-3 {
+    padding: 15px !important;
+  }
+
+  .p-lg-4 {
+    padding: 25px !important;
+  }
+
+  .p-lg-5 {
+    padding: 50px !important;
+  }
+
+  .pt-lg-0 {
+    padding-top: 0 !important;
+  }
+
+  .pt-lg-1 {
+    padding-top: 5px !important;
+  }
+
+  .pt-lg-2 {
+    padding-top: 10px !important;
+  }
+
+  .pt-lg-3 {
+    padding-top: 15px !important;
+  }
+
+  .pt-lg-4 {
+    padding-top: 25px !important;
+  }
+
+  .pt-lg-5 {
+    padding-top: 50px !important;
+  }
+
+  .pr-lg-0 {
+    padding-right: 0 !important;
+  }
+
+  .pr-lg-1 {
+    padding-right: 5px !important;
+  }
+
+  .pr-lg-2 {
+    padding-right: 10px !important;
+  }
+
+  .pr-lg-3 {
+    padding-right: 15px !important;
+  }
+
+  .pr-lg-4 {
+    padding-right: 25px !important;
+  }
+
+  .pr-lg-5 {
+    padding-right: 50px !important;
+  }
+
+  .pb-lg-0 {
+    padding-bottom: 0 !important;
+  }
+
+  .pb-lg-1 {
+    padding-bottom: 5px !important;
+  }
+
+  .pb-lg-2 {
+    padding-bottom: 10px !important;
+  }
+
+  .pb-lg-3 {
+    padding-bottom: 15px !important;
+  }
+
+  .pb-lg-4 {
+    padding-bottom: 25px !important;
+  }
+
+  .pb-lg-5 {
+    padding-bottom: 50px !important;
+  }
+
+  .pl-lg-0 {
+    padding-left: 0 !important;
+  }
+
+  .pl-lg-1 {
+    padding-left: 5px !important;
+  }
+
+  .pl-lg-2 {
+    padding-left: 10px !important;
+  }
+
+  .pl-lg-3 {
+    padding-left: 15px !important;
+  }
+
+  .pl-lg-4 {
+    padding-left: 25px !important;
+  }
+
+  .pl-lg-5 {
+    padding-left: 50px !important;
+  }
+
+  .m-lg-0 {
+    margin: 0 !important;
+  }
+
+  .m-lg-1 {
+    margin: 5px !important;
+  }
+
+  .m-lg-2 {
+    margin: 10px !important;
+  }
+
+  .m-lg-3 {
+    margin: 15px !important;
+  }
+
+  .m-lg-4 {
+    margin: 25px !important;
+  }
+
+  .m-lg-5 {
+    margin: 50px !important;
+  }
+
+  .mt-lg-0 {
+    margin-top: 0 !important;
+  }
+
+  .mt-lg-1 {
+    margin-top: 5px !important;
+  }
+
+  .mt-lg-2 {
+    margin-top: 10px !important;
+  }
+
+  .mt-lg-3 {
+    margin-top: 15px !important;
+  }
+
+  .mt-lg-4 {
+    margin-top: 25px !important;
+  }
+
+  .mt-lg-5 {
+    margin-top: 50px !important;
+  }
+
+  .mr-lg-0 {
+    margin-right: 0 !important;
+  }
+
+  .mr-lg-1 {
+    margin-right: 5px !important;
+  }
+
+  .mr-lg-2 {
+    margin-right: 10px !important;
+  }
+
+  .mr-lg-3 {
+    margin-right: 15px !important;
+  }
+
+  .mr-lg-4 {
+    margin-right: 25px !important;
+  }
+
+  .mr-lg-5 {
+    margin-right: 50px !important;
+  }
+
+  .mb-lg-0 {
+    margin-bottom: 0 !important;
+  }
+
+  .mb-lg-1 {
+    margin-bottom: 5px !important;
+  }
+
+  .mb-lg-2 {
+    margin-bottom: 10px !important;
+  }
+
+  .mb-lg-3 {
+    margin-bottom: 15px !important;
+  }
+
+  .mb-lg-4 {
+    margin-bottom: 25px !important;
+  }
+
+  .mb-lg-5 {
+    margin-bottom: 50px !important;
+  }
+
+  .ml-lg-0 {
+    margin-left: 0 !important;
+  }
+
+  .ml-lg-1 {
+    margin-left: 5px !important;
+  }
+
+  .ml-lg-2 {
+    margin-left: 10px !important;
+  }
+
+  .ml-lg-3 {
+    margin-left: 15px !important;
+  }
+
+  .ml-lg-4 {
+    margin-left: 25px !important;
+  }
+
+  .ml-lg-5 {
+    margin-left: 50px !important;
+  }
+}
+.d-none {
+  display: none !important;
+}
+
+.d-inline {
+  display: inline !important;
+}
+
+.d-inline-block {
+  display: inline-block !important;
+}
+
+.d-block {
+  display: block !important;
+}
+
+.d-table {
+  display: table !important;
+}
+
+.d-table-row {
+  display: table-row !important;
+}
+
+.d-table-cell {
+  display: table-cell !important;
+}
+
+.d-flex {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display:         flex !important;
+}
+
+.d-inline-flex {
+  display: -webkit-inline-box !important;
+  display: -webkit-inline-flex !important;
+  display: -ms-inline-flexbox !important;
+  display:         inline-flex !important;
+}
+
+@media (min-width: 768px) {
+  .d-sm-none {
+    display: none !important;
+  }
+
+  .d-sm-inline {
+    display: inline !important;
+  }
+
+  .d-sm-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-sm-block {
+    display: block !important;
+  }
+
+  .d-sm-table {
+    display: table !important;
+  }
+
+  .d-sm-table-row {
+    display: table-row !important;
+  }
+
+  .d-sm-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-sm-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-sm-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+
+  .d-sm-none {
+    display: none !important;
+  }
+
+  .d-sm-inline {
+    display: inline !important;
+  }
+
+  .d-sm-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-sm-block {
+    display: block !important;
+  }
+
+  .d-sm-table {
+    display: table !important;
+  }
+
+  .d-sm-table-row {
+    display: table-row !important;
+  }
+
+  .d-sm-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-sm-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-sm-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+}
+@media (min-width: 992px) {
+  .d-md-none {
+    display: none !important;
+  }
+
+  .d-md-inline {
+    display: inline !important;
+  }
+
+  .d-md-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-md-block {
+    display: block !important;
+  }
+
+  .d-md-table {
+    display: table !important;
+  }
+
+  .d-md-table-row {
+    display: table-row !important;
+  }
+
+  .d-md-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-md-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-md-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+
+  .d-md-none {
+    display: none !important;
+  }
+
+  .d-md-inline {
+    display: inline !important;
+  }
+
+  .d-md-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-md-block {
+    display: block !important;
+  }
+
+  .d-md-table {
+    display: table !important;
+  }
+
+  .d-md-table-row {
+    display: table-row !important;
+  }
+
+  .d-md-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-md-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-md-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+}
+@media (min-width: 1200px) {
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .d-lg-inline {
+    display: inline !important;
+  }
+
+  .d-lg-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+
+  .d-lg-table {
+    display: table !important;
+  }
+
+  .d-lg-table-row {
+    display: table-row !important;
+  }
+
+  .d-lg-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-lg-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-lg-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .d-lg-inline {
+    display: inline !important;
+  }
+
+  .d-lg-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+
+  .d-lg-table {
+    display: table !important;
+  }
+
+  .d-lg-table-row {
+    display: table-row !important;
+  }
+
+  .d-lg-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-lg-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-lg-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+}
+@media print {
+  .d-print-none {
+    display: none !important;
+  }
+
+  .d-print-inline {
+    display: inline !important;
+  }
+
+  .d-print-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-print-block {
+    display: block !important;
+  }
+
+  .d-print-table {
+    display: table !important;
+  }
+
+  .d-print-table-row {
+    display: table-row !important;
+  }
+
+  .d-print-table-cell {
+    display: table-cell !important;
+  }
+
+  .d-print-flex {
+    display: -webkit-box !important;
+    display: -webkit-flex !important;
+    display: -ms-flexbox !important;
+    display:         flex !important;
+  }
+
+  .d-print-inline-flex {
+    display: -webkit-inline-box !important;
+    display: -webkit-inline-flex !important;
+    display: -ms-inline-flexbox !important;
+    display:         inline-flex !important;
+  }
+}
+.float-xs-left {
+  float: left !important;
+}
+
+.float-xs-right {
+  float: right !important;
+}
+
+.float-xs-none {
+  float: none !important;
+}
+
+@media (min-width: 768px) {
+  .float-sm-left {
+    float: left !important;
+  }
+
+  .float-sm-right {
+    float: right !important;
+  }
+
+  .float-sm-none {
+    float: none !important;
+  }
+}
+@media (min-width: 992px) {
+  .float-md-left {
+    float: left !important;
+  }
+
+  .float-md-right {
+    float: right !important;
+  }
+
+  .float-md-none {
+    float: none !important;
+  }
+}
+@media (min-width: 1200px) {
+  .float-lg-left {
+    float: left !important;
+  }
+
+  .float-lg-right {
+    float: right !important;
+  }
+
+  .float-lg-none {
+    float: none !important;
+  }
+}
+.position-static {
+  position: static !important;
+}
+
+.position-relative {
+  position: relative !important;
+}
+
+.position-absolute {
+  position: absolute !important;
+}
+
+.position-fixed {
+  position: fixed !important;
+}
+
+.position-sticky {
+  position: -webkit-sticky !important;
+  position:         sticky !important;
+}
+
+.fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
+
+.fixed-bottom {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1030;
+}
+
+.sticky-top {
+  position: -webkit-sticky;
+  position:         sticky;
+  top: 0;
+  z-index: 1020;
+}
+
+.w-25 {
+  width: 25% !important;
+}
+
+.w-50 {
+  width: 50% !important;
+}
+
+.w-75 {
+  width: 75% !important;
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.h-25 {
+  height: 25% !important;
+}
+
+.h-50 {
+  height: 50% !important;
+}
+
+.h-75 {
+  height: 75% !important;
+}
+
+.h-100 {
+  height: 100% !important;
+}
+
+.mw-100 {
+  max-width: 100% !important;
+}
+
+.mh-100 {
+  max-height: 100% !important;
+}
+
+/*# sourceMappingURL=bootstrap-essentials.css.map */

--- a/src/AppBundle/Resources/public/js/bootstrap-essentials.js
+++ b/src/AppBundle/Resources/public/js/bootstrap-essentials.js
@@ -1,0 +1,689 @@
++ function ($) {
+    'use strict';
+
+    // SCROLLTO CLASS DEFINITION
+    // ======================
+
+    var scrto = '[data-toggle="scroll"][href*="#"]:not([href="#"])'
+    var Scrollto = function (element, options) {
+        this.element = '#' + $(element).attr('id')
+        this.$element = $(element)
+        this.options = $.extend({}, Scrollto.DEFAULTS, options)
+
+        if (this.options.toggle) this.toggle();
+    }
+
+    Scrollto.VERSION = '0.3.0'
+
+    Scrollto.TRANSITION_DURATION = 'slow'
+
+    Scrollto.DEFAULTS = {
+        toggle: true,
+        target: '0'
+    }
+
+    Scrollto.prototype.toggle = function () {
+        //if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && location.hostname == this.hostname) {
+            var target, hash
+
+            if (this.$element !== undefined && this.element.indexOf('#') === 0) {
+                target = $(this.element)
+                hash = this.element
+            } else {
+                target = $(this.hash)
+                hash = this.hash
+                target = target.length ? target : $('[name=' + this.hash.slice(1) + ']')
+            }
+
+            
+            if (target.length) {
+                $('html, body').animate({
+                    scrollTop: target.offset().top
+                }, Scrollto.TRANSITION_DURATION, function () {
+                    setTimeout(function () {
+                        window.location.hash = hash
+                    }, 50)
+                })
+
+                return false
+            }
+        //}
+    }
+
+    // SCROLLTO PLUGIN DEFINITION
+    // =======================
+
+    function Plugin(option) {
+        return this.each(function () {
+            var $this = $(this)
+            var data = $this.data('bs.scrollto')
+            var options = $.extend({}, Scrollto.DEFAULTS, $this.data(), typeof option === 'object' && option)
+
+            if (!data) $this.data('bs.scrollto', (data = new Scrollto(this, options)))
+            if (typeof option === 'string') data[option]()
+        })
+    }
+
+    var old = $.fn.scrollto
+
+    $.fn.scrollto = Plugin
+    $.fn.scrollto.Constructor = Scrollto
+
+
+    // SCROLLTO NO CONFLICT
+    // =================
+
+    $.fn.scrollto.noConflict = function () {
+        $.fn.scrollto = old
+        return this
+    }
+
+
+    // SCROLLTO DATA-API
+    // ==============
+
+    $(document).on('click', scrto, Scrollto.prototype.toggle)
+
+}(jQuery);
+/* ========================================================================
+ * Bootstrap: offcanvas.js v3.1.3
+ * http://jasny.github.io/bootstrap/javascript/#offcanvas
+ * ========================================================================
+ * Copyright 2013-2014 Arnold Daniels
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ======================================================================== */
+
++function ($) { "use strict";
+
+  // OFFCANVAS PUBLIC CLASS DEFINITION
+  // =================================
+
+  var OffCanvas = function (element, options) {
+    this.$element = $(element)
+    this.options  = $.extend({}, OffCanvas.DEFAULTS, options)
+    this.state    = null
+    this.placement = null
+    this.$calcClone = null
+
+    if (this.options.recalc) {
+      this.calcClone()
+      $(window).on('resize', $.proxy(this.recalc, this))
+    }
+
+    if (this.options.autohide && !this.options.modal) {
+      var eventName = (navigator.userAgent.match(/(iPad|iPhone)/i) === null) ? 'click' : 'touchstart'
+      $(document).on('click touchstart', $.proxy(this.autohide, this))
+    }
+
+    if (this.options.toggle) this.toggle()
+
+    if (this.options.disablescrolling) {
+        this.options.disableScrolling = this.options.disablescrolling
+        delete this.options.disablescrolling
+    }
+  }
+
+  OffCanvas.DEFAULTS = {
+    toggle: true,
+    placement: 'auto',
+    autohide: true,
+    recalc: true,
+    disableScrolling: false,
+    modal: true
+  }
+
+  OffCanvas.prototype.setWidth = function () {
+    var size = this.$element.outerWidth()
+    var max = $(window).width()
+    max -= 68 //Minimum space between menu and screen edge
+
+    this.$element.css('width', size > max ? max : size)
+  }
+
+  OffCanvas.prototype.offset = function () {
+    switch (this.placement) {
+      case 'left':
+      case 'right':  return this.$element.outerWidth()
+      case 'top':
+      case 'bottom': return this.$element.outerHeight()
+    }
+  }
+
+  OffCanvas.prototype.calcPlacement = function () {
+    if (this.options.placement !== 'auto') {
+        this.placement = this.options.placement
+        return
+    }
+
+    if (!this.$element.hasClass('in')) {
+      this.$element.css('visiblity', 'hidden !important').addClass('in')
+    }
+
+    var horizontal = $(window).width() / this.$element.width()
+    var vertical = $(window).height() / this.$element.height()
+
+    var element = this.$element
+    function ab(a, b) {
+      if (element.css(b) === 'auto') return a
+      if (element.css(a) === 'auto') return b
+
+      var size_a = parseInt(element.css(a), 10)
+      var size_b = parseInt(element.css(b), 10)
+
+      return size_a > size_b ? b : a
+    }
+
+    this.placement = horizontal >= vertical ? ab('left', 'right') : ab('top', 'bottom')
+
+    if (this.$element.css('visibility') === 'hidden !important') {
+      this.$element.removeClass('in').css('visiblity', '')
+    }
+  }
+
+  OffCanvas.prototype.opposite = function (placement) {
+    switch (placement) {
+      case 'top':    return 'bottom'
+      case 'left':   return 'right'
+      case 'bottom': return 'top'
+      case 'right':  return 'left'
+    }
+  }
+
+  OffCanvas.prototype.getCanvasElements = function() {
+    // Return a set containing the canvas plus all fixed elements
+    var canvas = this.options.canvas ? $(this.options.canvas) : this.$element
+
+    var fixed_elements = canvas.find('*').filter(function() {
+      return $(this).css('position') === 'fixed'
+    }).not(this.options.exclude)
+
+    return canvas.add(fixed_elements)
+  }
+
+  OffCanvas.prototype.slide = function (elements, offset, callback) {
+    // Use jQuery animation if CSS transitions aren't supported
+    if (!$.support.transition) {
+      var anim = {}
+      anim[this.placement] = "+=" + offset
+      return elements.animate(anim, 350, callback)
+    }
+
+    var placement = this.placement
+    var opposite = this.opposite(placement)
+
+    elements.each(function() {
+      if ($(this).css(placement) !== 'auto')
+        $(this).css(placement, (parseInt($(this).css(placement), 10) || 0) + offset)
+
+      if ($(this).css(opposite) !== 'auto')
+        $(this).css(opposite, (parseInt($(this).css(opposite), 10) || 0) - offset)
+    })
+
+    this.$element
+      .one($.support.transition.end, callback)
+      .emulateTransitionEnd(350)
+  }
+
+  OffCanvas.prototype.disableScrolling = function() {
+    var bodyWidth = $('body').width()
+    var prop = 'padding-right'
+
+    if ($('body').data('offcanvas-style') === undefined) {
+      $('body').data('offcanvas-style', $('body').attr('style') || '')
+    }
+    setTimeout(function() {
+      $('body').css('position', 'fixed')
+    }, 350)
+
+    if ($('body').width() > bodyWidth) {
+      var padding = parseInt($('body').css(prop), 10) + $('body').width() - bodyWidth
+
+      setTimeout(function() {
+        $('body').css(prop, padding)
+      }, 1)
+    }
+    //disable scrolling on mobiles (they ignore overflow:hidden)
+    // $('body').on('touchmove.bs', function(e) {
+    //   if (!$(event.target).closest('.offcanvas').length)
+    //     e.preventDefault();
+    // });
+  }
+
+  OffCanvas.prototype.enableScrolling = function() {
+    $('body').off('touchmove.bs');
+  }
+
+  OffCanvas.prototype.show = function () {
+    if (this.state) return
+
+    var startEvent = $.Event('show.bs.offcanvas')
+    this.$element.trigger(startEvent)
+    if (startEvent.isDefaultPrevented()) return
+
+    this.state = 'slide-in'
+    this.$element.css('width', '')
+    this.calcPlacement()
+    this.setWidth()
+
+    var elements = this.getCanvasElements()
+    var placement = this.placement
+    var opposite = this.opposite(placement)
+    var offset = this.offset()
+
+    if (elements.index(this.$element) !== -1) {
+      $(this.$element).data('offcanvas-style', $(this.$element).attr('style') || '')
+      this.$element.css(placement, -1 * offset)
+      this.$element.css(placement); // Workaround: Need to get the CSS property for it to be applied before the next line of code
+    }
+
+    elements.addClass('canvas-sliding').each(function() {
+      var $this = $(this)
+      if ($this.data('offcanvas-style') === undefined) $this.data('offcanvas-style', $this.attr('style') || '')
+      if ($this.css('position') === 'static') $this.css('position', 'relative')
+      if (($this.css(placement) === 'auto' || $this.css(placement) === '0px') &&
+          ($this.css(opposite) === 'auto' || $this.css(opposite) === '0px')) {
+        $this.css(placement, 0)
+      }
+    })
+
+    if (this.options.disableScrolling) this.disableScrolling()
+    if (this.options.modal) this.toggleBackdrop()
+
+    var complete = function () {
+      if (this.state != 'slide-in') return
+
+      this.state = 'slid'
+
+      elements.removeClass('canvas-sliding').addClass('canvas-slid')
+      this.$element.trigger('shown.bs.offcanvas')
+    }
+
+    setTimeout($.proxy(function() {
+      this.$element.addClass('in')
+      this.slide(elements, offset, $.proxy(complete, this))
+    }, this), 1)
+  }
+
+  OffCanvas.prototype.hide = function (fast) {
+    if (this.state !== 'slid') return
+
+    var startEvent = $.Event('hide.bs.offcanvas')
+    this.$element.trigger(startEvent)
+    if (startEvent.isDefaultPrevented()) return
+
+    this.state = 'slide-out'
+
+    var elements = $('.canvas-slid')
+    var placement = this.placement
+    var offset = -1 * this.offset()
+
+    var complete = function () {
+      if (this.state != 'slide-out') return
+
+      this.state = null
+      this.placement = null
+
+      this.$element.removeClass('in')
+
+      elements.removeClass('canvas-sliding')
+      elements.add(this.$element).add('body').each(function() {
+        $(this).attr('style', $(this).data('offcanvas-style')).removeData('offcanvas-style')
+      })
+
+      this.$element.trigger('hidden.bs.offcanvas')
+    }
+
+    if (this.options.disableScrolling) this.enableScrolling()
+    if (this.options.modal) this.toggleBackdrop()
+
+    elements.removeClass('canvas-slid').addClass('canvas-sliding')
+
+    setTimeout($.proxy(function() {
+      this.slide(elements, offset, $.proxy(complete, this))
+    }, this), 1)
+  }
+
+  OffCanvas.prototype.toggle = function () {
+    if (this.state === 'slide-in' || this.state === 'slide-out') return
+    this[this.state === 'slid' ? 'hide' : 'show']()
+  }
+
+  OffCanvas.prototype.toggleBackdrop = function (callback) {
+    callback = callback || $.noop;
+    if (this.state == 'slide-in') {
+      var doAnimate = $.support.transition;
+
+      this.$backdrop = $('<div class="modal-backdrop navmenu-modal fade" />')
+      .insertAfter(this.$element);
+
+      if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
+
+      this.$backdrop.addClass('in')
+      this.$backdrop.on('click.bs', $.proxy(this.autohide, this))
+
+      doAnimate ?
+        this.$backdrop
+        .one($.support.transition.end, callback)
+        .emulateTransitionEnd(150) :
+        callback()
+    } else if (this.state == 'slide-out' && this.$backdrop) {
+      this.$backdrop.removeClass('in');
+      $('body').off('touchmove.bs');
+      var self = this;
+      if ($.support.transition) {
+        this.$backdrop
+          .one($.support.transition.end, function() {
+            self.$backdrop.remove();
+            callback()
+            self.$backdrop = null;
+          })
+        .emulateTransitionEnd(150);
+      } else {
+        this.$backdrop.remove();
+        this.$backdrop = null;
+        callback();
+      }
+    } else if (callback) {
+      callback()
+    }
+  }
+
+  OffCanvas.prototype.calcClone = function() {
+    this.$calcClone = $('.offcanvas-clone')
+
+    if (!this.$calcClone.length) {
+      this.$calcClone = this.$element.clone()
+        .addClass('offcanvas-clone')
+        .appendTo($('body'))
+        .html('')
+    }
+
+    this.$calcClone.removeClass('in')
+  }
+
+  OffCanvas.prototype.recalc = function () {
+    if (this.$calcClone.css('display') === 'none' || (this.state !== 'slid' && this.state !== 'slide-in')) return
+
+    this.state = null
+    this.placement = null
+    var elements = this.getCanvasElements()
+
+    this.$element.removeClass('in')
+
+    elements.removeClass('canvas-slid')
+    elements.add(this.$element).add('body').each(function() {
+      $(this).attr('style', $(this).data('offcanvas-style')).removeData('offcanvas-style')
+    })
+  }
+
+  OffCanvas.prototype.autohide = function (e) {
+    if ($(e.target).closest(this.$element).length === 0) this.hide()
+    var target = $(e.target);
+    if (!target.hasClass('dropdown-backdrop') && $(e.target).closest(this.$element).length === 0) this.hide()
+  }
+
+  // OFFCANVAS PLUGIN DEFINITION
+  // ==========================
+
+  var old = $.fn.offcanvas
+
+  $.fn.offcanvas = function (option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.offcanvas')
+      var options = $.extend({}, OffCanvas.DEFAULTS, $this.data(), typeof option === 'object' && option)
+
+      if (!data) $this.data('bs.offcanvas', (data = new OffCanvas(this, options)))
+      if (typeof option === 'string') data[option]()
+    })
+  }
+
+  $.fn.offcanvas.Constructor = OffCanvas
+
+
+  // OFFCANVAS NO CONFLICT
+  // ====================
+
+  $.fn.offcanvas.noConflict = function () {
+    $.fn.offcanvas = old
+    return this
+  }
+
+
+  // OFFCANVAS DATA-API
+  // =================
+
+  $(document).on('click.bs.offcanvas.data-api', '[data-toggle=offcanvas]', function (e) {
+    var $this   = $(this), href
+    var target  = $this.attr('data-target')
+        || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+    var $canvas = $(target)
+    var data    = $canvas.data('bs.offcanvas')
+    var option  = data ? 'toggle' : $this.data()
+
+    e.preventDefault();
+    e.stopPropagation()
+
+    if (data) data.toggle()
+      else $canvas.offcanvas(option)
+  })
+
+}(window.jQuery);
+/* ===========================================================
+ * Bootstrap: fileinput.js v3.1.3
+ * http://jasny.github.com/bootstrap/javascript/#fileinput
+ * ===========================================================
+ * Copyright 2012-2014 Arnold Daniels
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+
++function ($) { "use strict";
+
+  var isIE = window.navigator.appName == 'Microsoft Internet Explorer'
+
+  // FILEUPLOAD PUBLIC CLASS DEFINITION
+  // =================================
+
+  var Fileinput = function (element, options) {
+    this.$element = $(element)
+
+    this.$input = this.$element.find(':file')
+    if (this.$input.length === 0) return
+
+    this.name = this.$input.attr('name') || options.name
+
+    this.$hidden = this.$element.find('input[type=hidden][name="' + this.name + '"]')
+    if (this.$hidden.length === 0) {
+      this.$hidden = $('<input type="hidden">').insertBefore(this.$input)
+    }
+
+    this.$preview = this.$element.find('.fileinput-preview')
+    var height = this.$preview.css('height')
+    if (this.$preview.css('display') !== 'inline' && height !== '0px' && height !== 'none') {
+      this.$preview.css('line-height', height)
+    }
+
+    this.original = {
+      exists: this.$element.hasClass('fileinput-exists'),
+      preview: this.$preview.html(),
+      hiddenVal: this.$hidden.val()
+    }
+
+    this.listen()
+  }
+
+  Fileinput.prototype.listen = function() {
+    this.$input.on('change.bs.fileinput', $.proxy(this.change, this))
+    $(this.$input[0].form).on('reset.bs.fileinput', $.proxy(this.reset, this))
+
+    this.$element.find('[data-trigger="fileinput"]').on('click.bs.fileinput', $.proxy(this.trigger, this))
+    this.$element.find('[data-dismiss="fileinput"]').on('click.bs.fileinput', $.proxy(this.clear, this))
+  },
+
+  Fileinput.prototype.change = function(e) {
+    var files = e.target.files === undefined ? (e.target && e.target.value ? [{ name: e.target.value.replace(/^.+\\/, '')}] : []) : e.target.files
+
+    e.stopPropagation()
+
+    if (files.length === 0) {
+      this.clear()
+      this.$element.trigger('clear.bs.fileinput')
+      return
+    }
+
+    this.$hidden.val('')
+    this.$hidden.attr('name', '')
+    this.$input.attr('name', this.name)
+
+    var file = files[0]
+
+    if (this.$preview.length > 0 && (typeof file.type !== "undefined" ? file.type.match(/^image\/(gif|png|jpeg)$/) : file.name.match(/\.(gif|png|jpe?g)$/i)) && typeof FileReader !== "undefined") {
+      var reader = new FileReader()
+      var preview = this.$preview
+      var element = this.$element
+
+      reader.onload = function(re) {
+        var $img = $('<img>')
+        $img[0].src = re.target.result
+        files[0].result = re.target.result
+
+        element.find('.fileinput-filename').text(file.name)
+
+        // if parent has max-height, using `(max-)height: 100%` on child doesn't take padding and border into account
+        if (preview.css('max-height') != 'none') {
+          var mh = parseInt(preview.css('max-height'), 10) || 0
+          var pt = parseInt(preview.css('padding-top'), 10) || 0
+          var pb = parseInt(preview.css('padding-bottom'), 10) || 0
+          var bt = parseInt(preview.css('border-top'), 10) || 0
+          var bb = parseInt(preview.css('border-bottom'), 10) || 0
+
+          $img.css('max-height', mh - pt - pb - bt - bb)
+        }
+
+        preview.html($img)
+        element.addClass('fileinput-exists').removeClass('fileinput-new')
+
+        element.trigger('change.bs.fileinput', files)
+      }
+
+      reader.readAsDataURL(file)
+    } else {
+      this.$element.find('.fileinput-filename').text(file.name)
+      this.$preview.text(file.name)
+
+      this.$element.addClass('fileinput-exists').removeClass('fileinput-new')
+
+      this.$element.trigger('change.bs.fileinput')
+    }
+  },
+
+  Fileinput.prototype.clear = function(e) {
+    if (e) e.preventDefault()
+
+    this.$hidden.val('')
+    this.$hidden.attr('name', this.name)
+    this.$input.attr('name', '')
+
+    //ie8+ doesn't support changing the value of input with type=file so clone instead
+    if (isIE) {
+      var inputClone = this.$input.clone(true);
+      this.$input.after(inputClone);
+      this.$input.remove();
+      this.$input = inputClone;
+    } else {
+      this.$input.val('')
+    }
+
+    this.$preview.html('')
+    this.$element.find('.fileinput-filename').text('')
+    this.$element.addClass('fileinput-new').removeClass('fileinput-exists')
+
+    if (e !== undefined) {
+      this.$input.trigger('change')
+      this.$element.trigger('clear.bs.fileinput')
+    }
+  },
+
+  Fileinput.prototype.reset = function() {
+    this.clear()
+
+    this.$hidden.val(this.original.hiddenVal)
+    this.$preview.html(this.original.preview)
+    this.$element.find('.fileinput-filename').text('')
+
+    if (this.original.exists) this.$element.addClass('fileinput-exists').removeClass('fileinput-new')
+     else this.$element.addClass('fileinput-new').removeClass('fileinput-exists')
+
+    this.$element.trigger('reset.bs.fileinput')
+  },
+
+  Fileinput.prototype.trigger = function(e) {
+    this.$input.trigger('click')
+    e.preventDefault()
+  }
+
+
+  // FILEUPLOAD PLUGIN DEFINITION
+  // ===========================
+
+  var old = $.fn.fileinput
+
+  $.fn.fileinput = function (options) {
+    return this.each(function () {
+      var $this = $(this),
+          data = $this.data('bs.fileinput')
+      if (!data) $this.data('bs.fileinput', (data = new Fileinput(this, options)))
+      if (typeof options == 'string') data[options]()
+    })
+  }
+
+  $.fn.fileinput.Constructor = Fileinput
+
+
+  // FILEINPUT NO CONFLICT
+  // ====================
+
+  $.fn.fileinput.noConflict = function () {
+    $.fn.fileinput = old
+    return this
+  }
+
+
+  // FILEUPLOAD DATA-API
+  // ==================
+
+  $(document).on('click.fileinput.data-api', '[data-provides="fileinput"]', function (e) {
+    var $this = $(this)
+    if ($this.data('bs.fileinput')) return
+    $this.fileinput($this.data())
+
+    var $target = $(e.target).closest('[data-dismiss="fileinput"],[data-trigger="fileinput"]');
+    if ($target.length > 0) {
+      e.preventDefault()
+      $target.trigger('click.bs.fileinput')
+    }
+  })
+
+}(window.jQuery);

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -21,7 +21,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.9.0/css/bootstrap-markdown.min.css">
     {% stylesheets filter="cssrewrite,scssphp" output="css/app.css"
       'bundles/app/css/bootstrap.css'
-    	'bundles/app/css/style.scss'
+	  'bundles/app/css/bootstrap-essentials.css'
+      'bundles/app/css/style.scss'
       'bundles/app/css/icons.css'
       'bundles/app/css/languages.css'
     %}
@@ -61,9 +62,25 @@
               <ul class="dropdown-menu" role="menu">
                 <li><a href="{{ path('cards_search') }}">{{ 'nav.advancedsearch' | trans}}</a></li>
                 <li class="divider"></li>
-              {% for line in cards_data.allsetsdata() %}
-                <li><a href="{{ line['url'] }}">{{ line['label'] | raw }}</a></li>
-              {% endfor %}
+				{% set projectName = null %}
+	            {% for line in cards_data.allsetsdata() %}
+	              {% if projectName != line['projectName'] %}
+					{% if projectName != null %}
+	                  </ul>
+	                </li>
+	                {% endif %}
+	                {% set projectName = line['projectName'] %}
+	                <li class="divider"></li>
+	                <li class="dropdown-submenu">
+	                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> <span class="nav-label">{{ projectName }}</span><span class="caret"></span></a>
+	                  <ul class="dropdown-menu">
+	              {% endif %}
+	              	    <li><a href="{{ line['url'] }}">{{ line['label'] | raw }}</a></li>
+	            {% endfor %}
+	            {% if projectName != null %}
+	                  </ul>
+	                </li>
+	            {% endif %}
               </ul>
             </li>
             <li class="dropdown">
@@ -192,14 +209,15 @@
   
   {% javascripts filter="?jsqueeze" output="js/app.js"
     '@AppBundle/Resources/public/js/bootstrap.js'
-		'@AppBundle/Resources/public/js/fdb-all.min.js'
+	'@AppBundle/Resources/public/js/bootstrap-essentials.js'
+	'@AppBundle/Resources/public/js/fdb-all.min.js'
     '@AppBundle/Resources/public/js/jquery.toc.min.js'
     '@AppBundle/Resources/public/js/app.collection.js'
-		'@AppBundle/Resources/public/js/app.data.js'
-		'@AppBundle/Resources/public/js/app.format.js'
-		'@AppBundle/Resources/public/js/app.tip.js'
-		'@AppBundle/Resources/public/js/app.card_modal.js'
-		'@AppBundle/Resources/public/js/app.user.js'
+	'@AppBundle/Resources/public/js/app.data.js'
+	'@AppBundle/Resources/public/js/app.format.js'
+	'@AppBundle/Resources/public/js/app.tip.js'
+	'@AppBundle/Resources/public/js/app.card_modal.js'
+	'@AppBundle/Resources/public/js/app.user.js'
     '@AppBundle/Resources/public/js/app.binomial.js'
     '@AppBundle/Resources/public/js/app.hypergeometric.js'
     '@AppBundle/Resources/public/js/app.draw_simulator.js'
@@ -210,8 +228,8 @@
     '@AppBundle/Resources/public/js/app.diff.js'
     '@AppBundle/Resources/public/js/app.deck_history.js'
     '@AppBundle/Resources/public/js/app.deck_charts.js'
-		'@AppBundle/Resources/public/js/app.ui.js'
-    %}
+	'@AppBundle/Resources/public/js/app.ui.js'
+  %}
 	  <script src="{{ asset_url }}"></script>
 	{% endjavascripts %}
 

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -96,12 +96,16 @@ class CardsData
 			$known = count($set->getCards());
 			$max = $set->getSize();
 
-			$label = $set->getPosition() . '. <span class="icon-set-'.$set->getCode().'"></span> ' . $set->getName();
+			// This +100 position trick will allow to have side project numbered as 1-based
+			$index = $set->getPosition() > 99 ? $set->getPosition() % 100 : $set->getPosition();
+			$label = sprintf("%02d", $index) . '. <span class="icon-set-'.$set->getCode().'"></span> ' . $set->getName();
+
 			if($known < $max) {
 				$label = sprintf("%s (%d/%d)", $label, $known, $max);
 			}
 
 			$lines[] = array(
+					"projectName" => $set->getProjectName(),
 					"code" => $set->getCode(),
 					"label" => $label,
 					"available" => $set->getDateRelease() ? true : false,


### PR DESCRIPTION
As discussed by email some months ago, here is a PR to clearly separate community made projects from different groups.

Here is how it appears : 
<img width="428" alt="Capture d’écran 2020-12-19 à 16 46 44" src="https://user-images.githubusercontent.com/3064433/102693292-dd56c900-4219-11eb-9c96-3a93402ca781.png">


It has a **Doctrine migration** that add a project name field to the Card Set table... This field is filled from the JSON data you import. There is a little trick : to have a _1 based_ numeration inside a subgroup, as this index comes from the single position field, such a group needs to start its numbering from a hundred. For exemple, giving a set a project name + position 202 will make it appear in a subgroup, with index `02.`. It means you assign a hundred number to a project group. It's not so ugly because for TTS keeping such kind of high numbers will avoid card ids collisions.

This require the [corresponding PR](https://github.com/fafranco82/swdestinydb-json-data/pull/288) made on the data repository (for validating input data).