### PR TITLE
Behavior : default to format sets + do not hide reprints when filtering list

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -692,7 +692,11 @@ ui.setup_typeahead = function setup_typeahead() {
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var regexp = new RegExp(q, 'i');
+		cb(app.data.cards.find({name: regexp}));
+		/* 
+		Do not hide reprinted cards, displays them all if needed
 		cb(app.data.cards.find({name: regexp, reprint_of: {$exists: false}}));
+		*/
 	}
 
 	$('#filter-text').typeahead({

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -203,7 +203,9 @@ ui.build_set_selector = function build_set_selector() {
 	    }
 	}).forEach(function(record) {
 		// checked or unchecked ? checked by default
-		var checked = !!record.available;
+		// var checked = !!record.available;
+		// ... Give priority to the sets belonging to the format you are editing ?
+		var checked = _.includes(app.deck.get_format_data().data.sets, record.code);
 		$('<li><a href="#"><label><input type="checkbox" name="' + record.code + '"' + (checked ? ' checked="checked"' : '') + '>' + record.name + '</label></a></li>').appendTo('[data-filter=set_code]');
 	});
 }

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -605,7 +605,10 @@ ui.refresh_list = _.debounce(function refresh_list(refresh) {
 		container = $('#collection-table'),
 		filters = ui.get_filters(),
 		query = $.extend({}, app.smart_filter.get_query(filters), {
-			reprint_of: {$exists: false}
+			/* 
+			Do not hide reprinted cards, displays them all if needed
+			reprint_of: {$exists: false} 
+			*/
 		}, true),
 		orderBy = {};
 


### PR DESCRIPTION
I've seen sometimes discussion about this on Facebook or other chats. The fact is that when you edit a deck : 
- All sets are preselected. While you'll not need some if you are not in INF format.
- But if you remove the sets you don't need, you'll not see the reprinted cards.

So here is an attempt to do better : 
- First, select only the sets belonging to the format of the deck you are editing
- Secondly, simply display the reprinted cards (and allow to find them directly).

The only disadvantage I see is that you can add 2 times a reprinted card and 2 times an original one. Without the app complaining about it. But as the cards are listed right next to each others in your decklist, you spot it easily. I don't think it's a good idea to block original cards too ; as a player that only have an old one in its collection will use this one. Players are still responsible of some parts of the validation, like for points management on plots affecting your deck only if you play 3 sets or things like that.

<img width="231" alt="Capture d’écran 2020-12-19 à 19 08 16" src="https://user-images.githubusercontent.com/3064433/102696442-9c1ce400-422e-11eb-8a36-801a9f765056.png">