### PR TITLE
Fixes #304 - Hide pointless sides B of Transformations set

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -621,7 +621,8 @@ ui.refresh_list = _.debounce(function refresh_list(refresh) {
 		var unusable = !app.deck.can_include_card(card);
 		if (!Config['show-unusable'] && unusable) return;
 		if (Config['show-only-owned'] && card.maxqty.cards==0) return;
-
+		if(card.type_code=='plot' && !card.points) return; // Hide some plots face B
+		
 		var row = divs[card.code];
 		if(!row || refresh) row = divs[card.code] = ui.build_row(card);
 


### PR DESCRIPTION
Wider than TR set : any plot that hasn't points should not be selectable for direct inclusion in a deck.

_Pay attention : you should first check bigger PRs I've made and take this one as last one ; to avoid merging problems._