### PR TITLE
Fix JS error on legality and points array when displaying an image

### DIFF
--- a/src/AppBundle/Resources/public/hbs/deck-layout-standard-09114.handlebars
+++ b/src/AppBundle/Resources/public/hbs/deck-layout-standard-09114.handlebars
@@ -96,7 +96,7 @@
 							{{#if (restricted code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
-							{{#if (errata code)}}
+							{{#if (erratad code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
 						</div>
@@ -133,7 +133,7 @@
                     {{#if (restricted code)}}
                     	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                     {{/if}}
-					{{#if (errata code)}}
+					{{#if (erratad code)}}
                     	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
                     {{/if}}
 				</div>
@@ -168,7 +168,7 @@
                    {{#if (restricted code)}}
                    <span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                    {{/if}}
-				   {{#if (errata code)}}
+				   {{#if (erratad code)}}
 					   <span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
 				   {{/if}}
 				</div>

--- a/src/AppBundle/Resources/public/hbs/deck-layout-standard.handlebars
+++ b/src/AppBundle/Resources/public/hbs/deck-layout-standard.handlebars
@@ -94,7 +94,7 @@
 							{{#if (restricted code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
-							{{#if (errata code)}}
+							{{#if (erratad code)}}
 		                    	<span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
 		                    {{/if}}
 						</div>
@@ -133,7 +133,7 @@
                    {{#if (restricted code)}}
                    <span class="fa fa-exclamation" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
                    {{/if}}
-				   {{#if (errata code)}}
+				   {{#if (erratad code)}}
 					   <span class="fa fa-exclamation" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
 				   {{/if}}
 				</div>

--- a/src/AppBundle/Resources/public/hbs/ui_card-legality.handlebars
+++ b/src/AppBundle/Resources/public/hbs/ui_card-legality.handlebars
@@ -13,7 +13,7 @@
 			    {{#if (errata ../card.code format.code)}}
 					<span class="fa fa-lg fa-exclamation-triangle" data-toggle="tooltip" title="{{trans 'card.format.errata'}}"></span>
 				{{else}}
-					{{#if (banned ../card.code format.code)}}
+					{{#if (ban ../card.code format.code)}}
 						<span class="fa fa-lg fa-times-circle" data-toggle="tooltip" title="{{trans 'card.format.banned'}}"></span>
 					{{else}}
 						<span class="fa fa-lg {{ternary (legal ../card.code format.code) 'fa-check-circle' 'fa-ban'}}"></span>

--- a/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
+++ b/src/AppBundle/Resources/public/hbs/ui_deckedit-display-1columns.handlebars
@@ -6,7 +6,7 @@
         {{#if (restricted card.code)}}
         <span class="fa fa-exclamation text-danger" title="{{trans 'card.info.restricted'}}" data-toggle="tooltip"></span>
         {{/if}}
-		{{#if (errata card.code)}}
+		{{#if (erratad card.code)}}
         <span class="fa fa-exclamation text-danger" title="{{trans 'card.format.errata'}}" data-toggle="tooltip"></span>
         {{/if}}
     </td>

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -52,7 +52,7 @@ Handlebars.registerHelper('restricted', function(code) {
 	return _.includes(app.deck.get_format_data().data.restricted, code);
 });	
 
-Handlebars.registerHelper('errata', function(code) {
+Handlebars.registerHelper('erratad', function(code) {
 	return _.includes(app.deck.get_format_data().data.errata, code);
 });	
 

--- a/src/AppBundle/Resources/public/js/handlebars-helpers.js
+++ b/src/AppBundle/Resources/public/js/handlebars-helpers.js
@@ -135,9 +135,9 @@
 		return false;
 	});
 	
-	Handlebars.registerHelper('banned', function(card_code, format_code) {
+	Handlebars.registerHelper('ban', function(card_code, format_code) {
 		if(arguments < 2)
-			throw new Error("Handlerbars Helper 'banned' needs 2 parameters");
+			throw new Error("Handlerbars Helper 'ban' needs 2 parameters");
 
 		if(app.data && app.data.formats) {
 			var format = app.data.formats.findById(format_code);

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -11,7 +11,7 @@ Handlebars.registerHelper('restricted', function(code) {
 	return _.includes(app.deck.get_format_data().data.restricted, code);
 });	
 
-Handlebars.registerHelper('errata', function(code) {
+Handlebars.registerHelper('erratad', function(code) {
 	return _.includes(app.deck.get_format_data().data.errata, code);
 });	
 


### PR DESCRIPTION
Merging all preceeding PRs causes an error : Two handlebars helper were named the same (errata) and compiled in the same JS file in the end. I renamed one in `erratad`... -ed naming style will stay for helper that have access to one deck data (that's why `banned` becomes `ban`)