### PR TITLE
Missing sets while replacing icons + link to cards in text

### DIFF
--- a/src/AppBundle/Resources/public/js/handlebars-helpers.js
+++ b/src/AppBundle/Resources/public/js/handlebars-helpers.js
@@ -22,33 +22,17 @@
     });
 
     Handlebars.registerHelper('text', function(text, opt) {
-        var str = text || '';
-        var icons = {
-            'blank': '<span class="icon-blank"></span>',
-            'discard': '<span class="icon-discard"></span>',
-            'disrupt': '<span class="icon-disrupt"></span>',
-            'focus': '<span class="icon-focus"></span>',
-            'melee': '<span class="icon-melee"></span>',
-            'ranged': '<span class="icon-ranged"></span>',
-            'indirect': '<span class="icon-indirect"></span>',
-            'shield': '<span class="icon-shield"></span>',
-            'resource': '<span class="icon-resource"></span>',
-            'special': '<span class="icon-special"></span>',
-            'unique': '<span class="icon-unique"></span>',
-            'AW': '<span class="icon-set-AW"></span>',
-            'SoR': '<span class="icon-set-SoR"></span>',
-            'EaW': '<span class="icon-set-EaW"></span>',
-            'TPG': '<span class="icon-set-TPG"></span>',
-            'LEG': '<span class="icon-set-LEG"></span>',
-            'RIV': '<span class="icon-set-RIV"></span>',
-            'WotF': '<span class="icon-set-WotF"></span>',
-            'AtG': '<span class="icon-set-AtG"></span>',
-            'CON': '<span class="icon-set-CON"></span>'
-        };
-        
-        _.forEach(icons, function(span, key) {
-            str = str.replace(new RegExp("\\["+key+"\\]", "g"), span);
-        });
+		if(!text) {
+			return new Handlebars.SafeString('<p></p>');
+		}
+        var str = text;
+		
+		// Look for fixed game icons
+		str = str.replace(new RegExp("\\[(blank|discard|disrupt|focus|melee|ranged|indirect|shield|resource|special|unique)\\]", "g"), '<span class="icon-$1"></span>');
+		
+		// Automatically look for remaining icons as set icons
+		str = str.replace(new RegExp("\\[([A-Za-z]*)\\]", "g"), '<span class="icon-set-$1"></span>');
+		
         str = str.split("\n").join('</p><p>');
         return new Handlebars.SafeString('<p>'+str+'</p>');
     });


### PR DESCRIPTION
There was some missing icons in cards text, like CONV and so on... I noticed it was an hardcoded list ; so here is a fix for that which first check for fixed game icons, the assume the rest of [TEXT] will represent a set icon (I don't see why it shouldn't stay like this in the future...). Using regex.

But it does event a little bit more : sometimes this set icon is followed by a card number, as the card text reference an other card... In that case, it tries to convert it as a link to the target card, which offer a quicker view of it. Concrete example : 
<img width="874" alt="Capture d’écran 2021-01-04 à 02 40 23" src="https://user-images.githubusercontent.com/3064433/103494269-54a17500-4e36-11eb-8074-2fcfb1807bb5.png">
