### PR TITLE
Feature : Transformation parallel dice

### DIFF
--- a/app/DoctrineMigrations/Version20210102191213.php
+++ b/app/DoctrineMigrations/Version20210102191213.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20210102191213 extends AbstractMigration
+{
+	/**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE card ADD parallel_die INT DEFAULT NULL');
+		$this->addSql('ALTER TABLE card ADD CONSTRAINT FK_161498D31C95D358 FOREIGN KEY (parallel_die) REFERENCES card (id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+		$this->addSql('ALTER TABLE card DROP CONSTRAINT FK_161498D31C95D358');
+        $this->addSql('ALTER TABLE card DROP COLUMN parallel_die');
+    }
+}

--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -603,6 +603,7 @@ class ImportStdCommand extends ContainerAwareCommand
 			$this->importCardDieSides($entity, $data);
 
 			$this->setReprintOf($entity, $data);
+			$this->setParallelDie($entity, $data);
 		}
 
 		// special case for StarterPack
@@ -697,10 +698,28 @@ class ImportStdCommand extends ContainerAwareCommand
 				$reprintOfCard = $this->em->getRepository("AppBundle:Card")->findOneBy(['code' => $data['reprint_of']]);
 
 			if(!$reprintOfCard)
-				throw new \Exception('Card ['.$card->getName().'] is marked as reprint of a card that doen\'t exists: '.$data["reprint_of"]);
+				throw new \Exception('Card ['.$card->getName().'] is marked as reprint of a card that doesn\'t exists: '.$data["reprint_of"]);
 
 			$card->setReprintOf($reprintOfCard);
 			$reprintOfCard->addReprint($card);
+		}
+	}
+	
+	protected function setParallelDie(Card $card, $data)
+	{
+		if(array_key_exists("parallel_die", $data))
+		{
+			$parallelDiceOfCard = NULL;
+			if(array_key_exists($data["parallel_die"], $this->tempCardMap))
+				$parallelDiceOfCard = $this->tempCardMap[$data["parallel_die"]];
+			else
+				$parallelDiceOfCard = $this->em->getRepository("AppBundle:Card")->findOneBy(['code' => $data['parallel_die']]);
+
+			if(!$parallelDiceOfCard)
+				throw new \Exception('Card ['.$card->getName().'] is marked as having parallel die a card that doesn\'t exists: '.$data["parallel_die"]);
+
+			$card->setParallelDie($parallelDiceOfCard);
+			$parallelDiceOfCard->addParallelDie($card);
 		}
 	}
 	

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -989,4 +989,73 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     {
         return $this->reprintOf;
     }
+	
+	/**
+     * @var \Doctrine\Common\Collections\Collection
+     */
+    private $parallelDiceOf;
+
+    /**
+     * @var \AppBundle\Entity\Card
+     */
+    private $parallelDie;
+
+
+    /**
+     * Add reprint
+     *
+     * @param \AppBundle\Entity\Card $reprint
+     *
+     * @return Card
+     */
+    public function addParallelDie(\AppBundle\Entity\Card $parallelDie)
+    {
+        $this->parallelDiceOf[] = $parallelDie;
+
+        return $this;
+    }
+
+    /**
+     * Remove reprint
+     *
+     * @param \AppBundle\Entity\Card $reprint
+     */
+    public function removeParallelDie(\AppBundle\Entity\Card $parallelDie)
+    {
+        $this->parallelDiceOf->removeElement($parallelDie);
+    }
+
+    /**
+     * Get reprints
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getParallelDiceOf()
+    {
+        return $this->parallelDiceOf;
+    }
+
+    /**
+     * Set parallelDiceOf
+     *
+     * @param \AppBundle\Entity\Card $parallelDie
+     *
+     * @return Card
+     */
+    public function setParallelDie(\AppBundle\Entity\Card $parallelDie = null)
+    {
+        $this->parallelDie = $parallelDie;
+
+        return $this;
+    }
+
+    /**
+     * Get parallelDie
+     *
+     * @return \AppBundle\Entity\Card
+     */
+    public function getParallelDie()
+    {
+        return $this->parallelDie;
+    }
 }

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -42,11 +42,21 @@ AppBundle\Entity\Card:
             joinColumn:
                 name: reprint_of
                 referencedColumnName: id
+        parallelDie:
+            targetEntity: Card
+            inversedBy: parallelDiceOf
+            joinColumn:
+                name: parallel_die
+                referencedColumnName: id
     oneToMany:
         reprints:
             targetEntity: Card
             orderBy: {'code': 'ASC'}
             mappedBy: reprintOf
+        parallelDiceOf:
+            targetEntity: Card
+            orderBy: {'code': 'ASC'}
+            mappedBy: parallelDie
         reviews:
             targetEntity: Review
             orderBy: {'dateCreation':'DESC'}

--- a/src/AppBundle/Resources/public/hbs/tip-card.handlebars
+++ b/src/AppBundle/Resources/public/hbs/tip-card.handlebars
@@ -75,7 +75,7 @@
 {{/if}}
 {{#if card.parallel_die}}
 	{{#with (card card.parallel_die)}}
-		<div class="card-parallel-die">{{trans 'card.info.parallelDie' card=(concat (set_icon set_code) ' ' set_name " #" position)}}.</div>
+		<div class="card-parallel-die">{{trans 'card.info.parallelDie' card=(concat name ' ' (set_icon set_code) " #" position)}}.</div>
 	{{/with}}
 {{/if}}
 {{#if card.parallel_dice_of}}
@@ -84,7 +84,7 @@
 		<ul class="card-parallel-dice-of-list">
 			{{#each card.parallel_dice_of}}
 			{{#with (card this)}}
-			<li><span class="icon-set-{{set_code}}"></span> {{set_name}} #{{position}}</li>
+			<li>{{name}} <span class="icon-set-{{set_code}}"></span> #{{position}}</li>
 			{{/with}}
 			{{/each}}
 		</ul>

--- a/src/AppBundle/Resources/public/hbs/tip-card.handlebars
+++ b/src/AppBundle/Resources/public/hbs/tip-card.handlebars
@@ -73,3 +73,20 @@
 		</ul>
 	</div>
 {{/if}}
+{{#if card.parallel_die}}
+	{{#with (card card.parallel_die)}}
+		<div class="card-parallel-die">{{trans 'card.info.parallelDie' card=(concat (set_icon set_code) ' ' set_name " #" position)}}.</div>
+	{{/with}}
+{{/if}}
+{{#if card.parallel_dice_of}}
+	<div class="card-parallel-dice-of">
+		{{trans "card.info.parallelDiceOf"}}:
+		<ul class="card-parallel-dice-of-list">
+			{{#each card.parallel_dice_of}}
+			{{#with (card this)}}
+			<li><span class="icon-set-{{set_code}}"></span> {{set_name}} #{{position}}</li>
+			{{/with}}
+			{{/each}}
+		</ul>
+	</div>
+{{/if}}

--- a/src/AppBundle/Resources/views/Search/card-set.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-set.html.twig
@@ -1,7 +1,8 @@
+<br/>
 <div class="card-set"><span class="icon-set-{{card.set_code}}"></span> {{ card.set_name }} #{{ card.position }}.</div>
 {% if card.reprint_of is defined %}
 	{% set reprint=cards_data.get_card_by_code(card.reprint_of) %}
-	<div class="card-reprint-of">{{ 'card.info.reprintOf' | trans({'%card%': '<span class="icon-set-'~reprint.set_code~'"></span> '~reprint.set_name~' #'~reprint.position}) | raw }}.</div>
+	<div class="card-reprint-of">{{ 'card.info.reprintOf' | trans({'%card%': '<a href="'~path('cards_zoom',{card_code:card.reprint_of})~'"><span class="icon-set-'~reprint.set_code~'"></span> '~reprint.set_name~' #'~reprint.position~'</a>'}) | raw }}.</div>
 {% endif %}
 {% if card.reprints is defined %}
 	<div class="card-reprints">
@@ -9,8 +10,24 @@
 		<ul class="card-reprints-list">
 			{% for code in card.reprints %}
 			{% set reprint=cards_data.get_card_by_code(code) %}
-			<li><span class="icon-set-{{reprint.set_code}}"></span> {{reprint.set_name}} #{{reprint.position}}</li>
+			<li><a href="{{path('cards_zoom',{card_code:code})}}"><span class="icon-set-{{reprint.set_code}}"></span> {{reprint.set_name}} #{{reprint.position}}</a></li>
 			{% endfor %}
 		</ul>
 	</div>
 {% endif %}
+{% if card.parallel_die is defined %}
+	{% set parallelDie=cards_data.get_card_by_code(card.parallel_die) %}
+	<div class="card-parallel-die">{{ 'card.info.parallelDie' | trans({'%card%': '<a href="'~path('cards_zoom',{card_code:card.parallel_die})~'"><span class="icon-set-'~parallelDie.set_code~'"></span> '~parallelDie.set_name~' #'~parallelDie.position~'</a>'}) | raw }}.</div>
+{% endif %}
+{% if card.parallel_dice_of is defined %}
+	<div class="card-parallel-dice-of">
+		{{"card.info.parallelDiceOf" | trans }}:
+		<ul class="card-parallel-dice-of-list">
+			{% for code in card.parallel_dice_of %}
+			{% set parallelDie=cards_data.get_card_by_code(code) %}
+			<li><a href="{{path('cards_zoom',{card_code:code})}}"><span class="icon-set-{{parallelDie.set_code}}"></span> {{parallelDie.set_name}} #{{parallelDie.position}}</a></li>
+			{% endfor %}
+		</ul>
+	</div>
+{% endif %}
+<br/>

--- a/src/AppBundle/Resources/views/Search/card-set.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-set.html.twig
@@ -17,7 +17,7 @@
 {% endif %}
 {% if card.parallel_die is defined %}
 	{% set parallelDie=cards_data.get_card_by_code(card.parallel_die) %}
-	<div class="card-parallel-die">{{ 'card.info.parallelDie' | trans({'%card%': '<a href="'~path('cards_zoom',{card_code:card.parallel_die})~'"><span class="icon-set-'~parallelDie.set_code~'"></span> '~parallelDie.set_name~' #'~parallelDie.position~'</a>'}) | raw }}.</div>
+	<div class="card-parallel-die">{{ 'card.info.parallelDie' | trans({'%card%': '<a href="'~path('cards_zoom',{card_code:card.parallel_die})~'">'~parallelDie.name~' <span class="icon-set-'~parallelDie.set_code~'"></span> #'~parallelDie.position~'</a>'}) | raw }}.</div>
 {% endif %}
 {% if card.parallel_dice_of is defined %}
 	<div class="card-parallel-dice-of">
@@ -25,7 +25,7 @@
 		<ul class="card-parallel-dice-of-list">
 			{% for code in card.parallel_dice_of %}
 			{% set parallelDie=cards_data.get_card_by_code(code) %}
-			<li><a href="{{path('cards_zoom',{card_code:code})}}"><span class="icon-set-{{parallelDie.set_code}}"></span> {{parallelDie.set_name}} #{{parallelDie.position}}</a></li>
+			<li><a href="{{path('cards_zoom',{card_code:code})}}">{{parallelDie.name}} <span class="icon-set-{{parallelDie.set_code}}"></span> #{{parallelDie.position}}</a></li>
 			{% endfor %}
 		</ul>
 	</div>

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -453,6 +453,18 @@ class CardsData
 	    	$cardinfo['reprint_of'] = $card->getReprintOf()->getCode();
 	    }
 
+		if(!$card->getParallelDiceOf()->isEmpty())
+	    {
+		    $cardinfo['parallel_dice_of'] = [];
+		    foreach ($card->getParallelDiceOf() as $parallelDie) {
+		    	$cardinfo['parallel_dice_of'][] = $parallelDie->getCode();
+		    }
+		}
+
+	    if($card->getParallelDie() != NULL)
+	    {
+	    	$cardinfo['parallel_die'] = $card->getParallelDie()->getCode();
+	    }
 
 		$cardinfo['url'] = $this->router->generate('cards_zoom', array('card_code' => $card->getCode()), UrlGeneratorInterface::ABSOLUTE_URL);
 


### PR DESCRIPTION
Transformation introduce the "parallel dice", a card that reuse the die of an other card. This is an implementation of this feature. It's based on the "reprint" feature of a card, and allow to display nicely a link to the reused card : 
<img width="575" alt="Capture d’écran 2021-01-04 à 02 51 55" src="https://user-images.githubusercontent.com/3064433/103494672-23c23f80-4e38-11eb-8c85-f08d28e0a929.png">

Two translation must be added to loco : 
- card.info.parallelDie = Parallel die is %card%
- card.info.parallelDiceOf = Used as parallel die by

Pay attention there is also a Doctrine migration to execute (20210102191213) ; and I have also made a PR for updating TR cards data.

_Note : What this feature doesn't do is managing the fact that you already own X of the previous dice in your collection. Would be nice, probably, but maybe later._