### PR TITLE
Proposal : Project link ?

### DIFF
--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -74,6 +74,13 @@
 	                <li class="dropdown-submenu">
 	                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> <span class="nav-label">{{ projectName }}</span><span class="caret"></span></a>
 	                  <ul class="dropdown-menu">
+                      
+                      {% if projectName == 'A Renewed Hope' %}
+                        <li><a href="https://swdrenewedhope.com" target="_blank"><span class="fa fa-external-link fa-fw"></span> {{ projectName }}</a></li>
+                      {% elseif projectName == 'The Coruscant Initiative' %}
+                        <li><a href="https://www.coruscant-initiative.org"  target="_blank"><span class="fa fa-external-link fa-fw"></span> {{ projectName }}</a></li>
+                      {% endif %}
+                      
 	              {% endif %}
 	              	    <li><a href="{{ line['url'] }}">{{ line['label'] | raw }}</a></li>
 	            {% endfor %}


### PR DESCRIPTION
I thought it could be good for random players to be able to access information about fan made sets... I thought adding a project_link field at the same level as project_name but it would mean each set ; it's too much.

The simplest way is here, hardcoding something in the menu. It's not so clean but as the info should not change often, I think the project can live with that. What do you think ?

<img width="446" alt="Capture d’écran 2021-01-04 à 04 07 31" src="https://user-images.githubusercontent.com/3064433/103497911-486fe480-4e43-11eb-9a9d-d5cba399a8ec.png">
