### PR TITLE
Global + and - buttons for adding bunch of cards to a collection

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.collection.js
+++ b/src/AppBundle/Resources/public/js/ui.collection.js
@@ -297,6 +297,31 @@ ui.on_submit_form = function on_submit_form(event) {
 			ui.on_quantity_change(code, otherColl, otherQty);
 	}
  }
+ 
+ /**
+  * sets up event handlers ; dataloaded not fired yet
+  * @memberOf ui
+  */
+  ui.on_all_spin = function on_all_spin(event) {
+ 	event.stopPropagation();
+
+	var inc = $(this).text()=='+' ? 1 : -1;
+	$('.card-container').each(function(index, element) {
+		var row = $(element);
+		var code = row.data('code');
+		
+		var qty = parseInt(row.find('[data-spin=cards]').find('span.value').text(), 10) + inc;
+		if(qty >= 0)
+			ui.on_quantity_change(code, 'cards', qty);
+			
+		//if cards and dice linked, update the other coll
+		if(Config['link-cards-dice']) {
+			var qty = parseInt(row.find('[data-spin=dice]').find('span.value').text(), 10) + inc;
+			if(qty >= 0)
+				ui.on_quantity_change(code, 'dice', qty);
+		}
+	})
+  }
 
 /**
  * sets up event handlers ; dataloaded not fired yet
@@ -400,6 +425,7 @@ ui.setup_event_handlers = function setup_event_handlers() {
 	$('#btn-save').on('click', ui.on_submit_form);
 
 	$('#collection').on('click', 'button.btn-spin', ui.on_button_spin);
+	$('#collection').on('click', 'button.btn-all-spin', ui.on_all_spin);
 
 	$('#filter-text').on('input', ui.on_input_smartfilter);
 	$('#config-options').on('change', 'input', ui.on_config_change);

--- a/src/AppBundle/Resources/views/Collection/index.html.twig
+++ b/src/AppBundle/Resources/views/Collection/index.html.twig
@@ -124,6 +124,10 @@
 					</th>
 					<th colspan="2">
 						<a href="#" data-sort="owned.cards">{{ 'collection.owned' | trans}}</a>
+						<div class="btn-group btn-group-xs btn-all-spinner">
+							<button class="btn btn-danger btn-all-spin hidden-print">-</button>
+							<button class="btn btn-success btn-all-spin hidden-print">+</button>
+						</div>
 					</th>
 					<th class="hidden-sm hidden-xs">
 						<a href="#" data-sort="affiliation_code">{{ 'card.info.affiliation' | trans }}</a>


### PR DESCRIPTION
Quite simple but it may become useful as sets are now not anymore collectible... I added a +/- button in the column header, which results in adding (or removing) one card to each row shown. And a dice if the current options is set on link quantities.

<img width="458" alt="image" src="https://user-images.githubusercontent.com/3064433/104476715-d6289e00-55c0-11eb-8b8d-7092dc9f5fe5.png">
