### PR TITLE
Adding 40 card limit to decks including CT4040 plot

### DIFF
--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -284,8 +284,13 @@ class DeckValidationHelper
 	public function findProblem(SlotCollectionProviderInterface $deck)
 	{
 		$deckSize = $this->getDeckSize($deck);
-		if($deckSize != 30) {
-			return 'incorrect_size';
+		if($deck->getSlots()->isSlotIncluded("15101")) {
+		  if($deckSize != 40) {
+			  return 'incorrect_size';
+		  }
+		  elseif($deckSize != 30) {
+			  return 'incorrect_size';
+		  }
 		}
 
 		if($deck->getSlots()->getCharacterPoints()+$deck->getSlots()->getPlotPoints() > 30) {


### PR DESCRIPTION
@fafranco82 this is step two to making that new plot I just submitted work.  For me, I think there's 3 steps to making the 40/40 format work:
Allow 40 points: achieved via the -10 plot
Allow 40 cards: hopefully works in this fix, which checks if that plot is included, and if so let's you include 40 cards.
Allow 2 plots if you have this plot. Currently don't know how to do that, but it's less urgent.
Thank you as always, and apologies if I've broken something.  I have literally never written anything in php before.