### PR TITLE
Remove autocorrect/spellcheck from card text search fields

### DIFF
--- a/src/AppBundle/Resources/views/Search/searchbar.html.twig
+++ b/src/AppBundle/Resources/views/Search/searchbar.html.twig
@@ -2,7 +2,7 @@
 	<form method="GET" action="{{ path('cards_find') }}" id="search-form" role="form">
 		<div class="col-sm-4">
 		<div class="input-group" style="margin-bottom:.5em">
-		  <input type="text" class="form-control smart-filter-help" size="30" name="q" tabindex="1" value="{{ q|default('') }}">
+		  <input type="text" class="form-control smart-filter-help" size="30" name="q" tabindex="1" value="{{ q|default('') }}" autocorrect="off" autocapitalize="off" spellcheck="false">
 		  <span class="input-group-btn">
 		      <button class="btn btn-primary" type="submit">{{ 'search.label' | trans}}</button>
 		  </span>

--- a/src/AppBundle/Resources/views/Search/searchform.html.twig
+++ b/src/AppBundle/Resources/views/Search/searchform.html.twig
@@ -33,7 +33,7 @@
         <div class="form-group">
 			<label for="q">{{ 'card.info.name' | trans }}</label>
 			<div>
-				<input class="form-control" size="30" id="q" name="q" value="">
+				<input class="form-control" size="30" id="q" name="q" value="" autocorrect="off" autocapitalize="off" spellcheck="false">
 			</div>
 		</div>
 	</div>
@@ -41,7 +41,7 @@
         <div class="form-group">
 			<label for="q">{{ 'card.info.subtitle' | trans }}</label>
 			<div>
-				<input class="form-control" size="30" id="l" name="l" value="">
+				<input class="form-control" size="30" id="l" name="l" value="" autocorrect="off" autocapitalize="off" spellcheck="false">
 			</div>
 		</div>
 	</div>
@@ -51,7 +51,7 @@
 		<div class="form-group">
 			<label for="x">{{ 'card.info.text' | trans }}</label>
 			<div>
-				<input class="form-control" size="40" id="x" name="x" value="">
+				<input class="form-control" size="40" id="x" name="x" value="" autocorrect="off" autocapitalize="off" spellcheck="false">
 			</div>
 		</div>
     </div>
@@ -59,7 +59,7 @@
 		<div class="form-group">
 			<label for="a">{{ 'card.info.flavor' | trans }}</label>
 			<div>
-				<input class="form-control" size="30" id="v" name="v" value="">
+				<input class="form-control" size="30" id="v" name="v" value="" autocorrect="off" autocapitalize="off" spellcheck="false">
 			</div>
 		</div>
 	</div>

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -74,13 +74,13 @@
 	                <li class="dropdown-submenu">
 	                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> <span class="nav-label">{{ projectName }}</span><span class="caret"></span></a>
 	                  <ul class="dropdown-menu">
-                      
+
                       {% if projectName == 'A Renewed Hope' %}
                         <li><a href="https://swdrenewedhope.com" target="_blank"><span class="fa fa-external-link fa-fw"></span> {{ projectName }}</a></li>
                       {% elseif projectName == 'The Coruscant Initiative' %}
                         <li><a href="https://www.coruscant-initiative.org"  target="_blank"><span class="fa fa-external-link fa-fw"></span> {{ projectName }}</a></li>
                       {% endif %}
-                      
+
 	              {% endif %}
 	              	    <li><a href="{{ line['url'] }}">{{ line['label'] | raw }}</a></li>
 	            {% endfor %}
@@ -103,7 +103,7 @@
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="fa fa-search"></span></a>
                 <div class="dropdown-menu">
                   <form action="{{ path('cards_find') }}" target="_blank">
-                    <input type="text" placeholder="{{ 'nav.cardsearch' | trans }}" class="form-control" name="q">
+                    <input type="text" placeholder="{{ 'nav.cardsearch' | trans }}" class="form-control" name="q" autocorrect="off" autocapitalize="off" spellcheck="false">
                   </form>
               </div>
             </li>
@@ -132,7 +132,7 @@
           </ul>
           <form class="navbar-form navbar-right visible-lg-block visible-xs-block external" action="{{ path('cards_find') }}" target="_blank">
             <div class="form-group">
-              <input type="text" placeholder="{{ 'nav.cardsearch' | trans }}" class="form-control" name="q">
+              <input type="text" placeholder="{{ 'nav.cardsearch' | trans }}" class="form-control" name="q" autocorrect="off" autocapitalize="off" spellcheck="false">
             </div>
           </form>
         </div><!--/.navbar-collapse -->
@@ -178,7 +178,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.9.0/js/bootstrap-markdown.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.3.0/handlebars.runtime.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/async/2.5.0/async.min.js"></script>
-    {% javascripts 
+    {% javascripts
       '@AppBundle/Resources/public/js/bootstrap-markdown.es.js'
       '@AppBundle/Resources/public/js/handlebars-helpers.js' %}
         <script src="{{ asset_url }}"></script>
@@ -206,14 +206,14 @@
 		<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 		{% include 'AppBundle:Default:google-analytics.html.twig' %}
 	{% endif %}
-  
+
   {% javascripts filter="?jsqueeze" output="js/templates.js"
     '@AppBundle/Resources/public/hbs/*.handlebars'
     '@AppBundle/Resources/public/js/register-partials.js'
     %}
     <script src="{{ asset_url }}"></script>
   {% endjavascripts %}
-  
+
   {% javascripts filter="?jsqueeze" output="js/app.js"
     '@AppBundle/Resources/public/js/bootstrap.js'
 	'@AppBundle/Resources/public/js/bootstrap-essentials.js'


### PR DESCRIPTION
Safari on macOS and iOS will rather aggressively auto-correct text in input fields if it believes the text has been misspelled. Unfortunately its default dictionary does not contain the wide variety of Star Wars names and terms and often autocorrects them to other words, which makes it tough to search SWDestinyDB (especially on mobile).

This change disables autocorrect on card search textboxes using the following attributes:
* [spellcheck](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) to disable spell check underlines
* [autocapitalize](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) because the search is already case-insensitive.
* [autocorrect](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect) a nonstandard Safari-only option that disables inline autocorrect.